### PR TITLE
Adding a category filter #1

### DIFF
--- a/cards.html
+++ b/cards.html
@@ -42,9 +42,23 @@
     <div class="panel-collapse collapse" id="filterlist">
       <div class="list-group">
         <div class="list-group-item">
-          <div class="form">
-            <label class="sr-only" for="traitfilter">Filter by trait</label>
-              <traits></traits>
+          <div class="form-horizontal">
+            <div class="form-group">
+              <label class="control-label col-sm-3" for="traitfilter">Filter by Card Trait:</label>
+              <div class="col-sm-9">
+                <traits></traits>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="list-group-item">
+          <div class="form-horizontal">
+            <div class="form-group">
+              <label class="control-label col-sm-3" for="categoryfilter">Filter by Category:</label>
+              <div class="col-sm-9">
+                <categories></categories>
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -54,8 +68,7 @@
   <div class="panel panel-primary visible-xs" id=filterpanel-xs>
     <div class="panel-heading clearfix" data-toggle="collapse" data-parent="#filterpanel-xs" style="cursor: pointer;" data-target="#filterlist-xs">
       <h2 class="panel-title">
-        <a data-toggle="collapse" style="vertical-align: middle;"> <span class="glyphicon glyphicon-filter"></span> Show Filters</a>
-        <button class="btn btn-default btn-xs pull-right" ng-click="cards.resetSearch();"> Reset </button>
+        <a data-toggle="collapse"> <span class="glyphicon glyphicon-filter"></span> Show Filters</a>
       </h2>
     </div>
     <div class="panel-collapse collapse" id="filterlist-xs">
@@ -86,15 +99,24 @@
             </form>
           </div>
           <div class="list-group-item">
-            <div class="form">
-              <label class="sr-only" for="traitfilter">Filter by trait</label>
-                <traits></traits>
-            </div>
-          </div>
-          <div class="list-group-item">
             <form class="form-inline">
               <input class="form-control" ng-model="cards.filtersettings.search.textc" type="search" placeholder="Search by card text">
             </form>
+          </div>
+          <div class="list-group-item">
+            <div class="form">
+              <label class="sr-only" for="traitfilter">Filter by trait</label>
+              <traits></traits>
+            </div>
+          </div>
+          <div class="list-group-item">
+            <div class="form">
+              <label class="sr-only" for="traitfilter">Filter by categories</label>
+              <categories></categories>
+            </div>
+          </div>
+          <div class="list-group-item">
+            <button class="btn btn-primary btn-block" ng-click="cards.resetSearch();"> Reset Filters</button>
           </div>
       </div>
     </div>

--- a/cards.html
+++ b/cards.html
@@ -35,7 +35,7 @@
               <button title="Fellowship" class="filter-button" ng-class="{selected: cards.filtersettings.spheres['7fellowship']}" ng-click="cards.toggleSphere('7fellowship',$event)"><img src="img/spheres/7fellowship.png"/></button>
             </div>
           </div>
-          <button class="btn btn-primary pull-right hidden-xs" data-toggle="collapse" data-parent="#filterpanel" data-target="#filterlist"> <span class="glyphicon glyphicon-filter"></span> Advanced Filters </button>
+          <button class="btn btn-primary pull-right" data-toggle="collapse" data-parent="#filterpanel" data-target="#filterlist"> <span class="glyphicon glyphicon-filter"></span> Advanced Filters </button>
         </form>
       </h2>
     </div>
@@ -124,7 +124,7 @@
   <!-- panel containing text filters and cardlist -->
   <div class="panel panel-default" id="cardlistpanel">
     <div class="panel-heading hidden-xs">
-      <button type="button" class="btn btn-primary btn-sm pull-right hidden-xs" ng-click="cards.resetSearch();"> Reset </button>
+      <button type="button" class="btn btn-primary btn-sm pull-right" style="min-width: 150px;" ng-click="cards.resetSearch();"> Reset </button>
       <form class="form-inline">
         <div class="form-group form-group-sm">
           <input class="form-control" ng-model="cards.filtersettings.search.name_norm" type="search" placeholder="Search by card name">

--- a/cards.json
+++ b/cards.json
@@ -110,7 +110,7 @@
     "textc": "Ranged.\nResponse: After Legolas participates in an attack that destroys an enemy, place 2 progress tokens on the current quest.",
     "name_norm": "Legolas",
     "octgn": "51223bd0-ffd1-11df-a976-0801200c9005",
-    "categories": ""
+    "categories": "Location Control"
   },
   {
     "name": "Thalin",
@@ -154,7 +154,7 @@
     "textc": "Action: Discard 1 card from your hand to give \u00c9owyn +1 Willpower until the end of the phase. This effect may be triggered by each player once each round.",
     "name_norm": "Eowyn",
     "octgn": "51223bd0-ffd1-11df-a976-0801200c9007",
-    "categories": ""
+    "categories": "Willpower Bonus"
   },
   {
     "name": "Eleanor",
@@ -198,7 +198,7 @@
     "textc": "D\u00fanhere can target enemies in the staging area when he attacks alone. When doing so, he gets +1 Attack.",
     "name_norm": "Dunhere",
     "octgn": "51223bd0-ffd1-11df-a976-0801200c9009",
-    "categories": "Attack Bonus"
+    "categories": "Attack Bonus, Staging Area Attack"
   },
   {
     "name": "Denethor",
@@ -310,7 +310,7 @@
     "name_norm": "Faramir",
     "corequantity": 2,
     "octgn": "51223bd0-ffd1-11df-a976-0801200c9014",
-    "categories": ""
+    "categories": "Willpower Bonus"
   },
   {
     "name": "Son of Arnor",
@@ -358,7 +358,7 @@
     "name_norm": "Snowbourn Scout",
     "corequantity": 3,
     "octgn": "51223bd0-ffd1-11df-a976-0801200c9016",
-    "categories": ""
+    "categories": "Location Control"
   },
   {
     "name": "Silverlode Archer",
@@ -566,7 +566,7 @@
     "name_norm": "Lorien Guide",
     "corequantity": 3,
     "octgn": "51223bd0-ffd1-11df-a976-0801200c9044",
-    "categories": ""
+    "categories": "Location Control"
   },
   {
     "name": "Northern Tracker",
@@ -590,7 +590,7 @@
     "name_norm": "Northern Tracker",
     "corequantity": 2,
     "octgn": "51223bd0-ffd1-11df-a976-0801200c9045",
-    "categories": ""
+    "categories": "Location Control"
   },
   {
     "name": "Daughter of the Nimrodel",
@@ -858,7 +858,7 @@
     "name_norm": "Celebrian's Stone",
     "corequantity": 1,
     "octgn": "51223bd0-ffd1-11df-a976-0801200c9027",
-    "categories": "Resource Smoothing"
+    "categories": "Resource Smoothing, Willpower Bonus"
   },
   {
     "name": "Blade Mastery",
@@ -1013,7 +1013,7 @@
     "name_norm": "Blade of Gondolin",
     "corequantity": 2,
     "octgn": "51223bd0-ffd1-11df-a976-0801200c9039",
-    "categories": "Attack Bonus"
+    "categories": "Attack Bonus, Location Control"
   },
   {
     "name": "Citadel Plate",
@@ -1109,7 +1109,7 @@
     "name_norm": "Strength of Will",
     "corequantity": 2,
     "octgn": "51223bd0-ffd1-11df-a976-0801200c9047",
-    "categories": ""
+    "categories": "Location Control"
   },
   {
     "name": "Hasty Stroke",
@@ -1263,7 +1263,7 @@
     "name_norm": "The Favor of the Lady",
     "corequantity": 2,
     "octgn": "51223bd0-ffd1-11df-a976-0801200c9055",
-    "categories": ""
+    "categories": "Willpower Bonus"
   },
   {
     "name": "Power in the Earth",
@@ -1282,7 +1282,7 @@
     "name_norm": "Power in the Earth",
     "corequantity": 2,
     "octgn": "51223bd0-ffd1-11df-a976-0801200c9056",
-    "categories": ""
+    "categories": "Location Control"
   },
   {
     "name": "Unexpected Courage",
@@ -1455,7 +1455,7 @@
     "name_norm": "Protector of Lorien",
     "corequantity": 2,
     "octgn": "51223bd0-ffd1-11df-a976-0801200c9070",
-    "categories": "Defense Bonus"
+    "categories": "Defense Bonus, Willpower Bonus"
   },
   {
     "name": "Dark Knowledge",
@@ -1886,7 +1886,7 @@
     "textc": "Action: Spend 1 Lore resource to give Longbeard Map-Maker +1 Willpower until the end of the phase.",
     "name_norm": "Longbeard Map-Maker",
     "octgn": "51223bd0-ffd1-11df-a976-0801202c9014",
-    "categories": ""
+    "categories": "Willpower Bonus"
   },
   {
     "name": "A Burning Brand",
@@ -1964,7 +1964,7 @@
     "textc": "Attach to a hero.\nAttached hero gains +1 Willpower.\nAction: Pay 1 resource from attached hero's pool to attach Dunedain Quest to another hero.",
     "name_norm": "Dunedain Quest",
     "octgn": "51223bd0-ffd1-11df-a976-0801203c9008",
-    "categories": ""
+    "categories": "Willpower Bonus"
   },
   {
     "name": "Parting Gifts",
@@ -2046,7 +2046,7 @@
     "textc": "While committed to a quest, Escort from Edoras gets +2 Willpower.\nForced: After resolving a quest to which Escort from Edoras was committed, discard Escort from Edoras from play.",
     "name_norm": "Escort from Edoras",
     "octgn": "51223bd0-ffd1-11df-a976-0801203c9009",
-    "categories": ""
+    "categories": "Willpower Bonus"
   },
   {
     "name": "Ancient Mathom",
@@ -2192,7 +2192,7 @@
     "textc": "Quest Action: Discard a Leadership ally to give each hero committed to this quest +1 Willpower until the end of the phase.",
     "name_norm": "Rear Guard",
     "octgn": "51223bd0-ffd1-11df-a976-0801204c9012",
-    "categories": ""
+    "categories": "Willpower Bonus"
   },
   {
     "name": "Descendant of Thorondor",
@@ -2254,7 +2254,7 @@
     "textc": "Action: Exhaust and discard The Riddermark's Finest to place 2 progress tokens on any location.",
     "name_norm": "The Riddermark's Finest",
     "octgn": "51223bd0-ffd1-11df-a976-0801204c9023",
-    "categories": ""
+    "categories": "Location Control"
   },
   {
     "name": "Ride to Ruin",
@@ -2272,7 +2272,7 @@
     "textc": "Action: Discard a Rohan ally to choose a location. Place 3 progress tokens on that location.",
     "name_norm": "Ride to Ruin",
     "octgn": "51223bd0-ffd1-11df-a976-0801204c9013",
-    "categories": ""
+    "categories": "Location Control"
   },
   {
     "name": "Gildor Inglorion",
@@ -2561,7 +2561,7 @@
     "textc": "While Dain Ironfoot is ready, Dwarf characters get +1 Attack and +1 Willpower.",
     "name_norm": "Dain Ironfoot",
     "octgn": "51223bd0-ffd1-11df-a976-0801206c9005",
-    "categories": "Attack Bonus"
+    "categories": "Attack Bonus, Willpower Bonus"
   },
   {
     "name": "D\u00fanedain Signal",
@@ -2662,7 +2662,7 @@
     "textc": "Response: After you play West Road Traveller from your hand, switch the active location with any other location in the staging area.",
     "name_norm": "West Road Traveller",
     "octgn": "51223bd0-ffd1-11df-a976-0801206c9026",
-    "categories": ""
+    "categories": "Location Control"
   },
   {
     "name": "Astonishing Speed",
@@ -2681,7 +2681,7 @@
     "textc": "Action: Until the end of the phase, all Rohan characters get +2 Willpower.",
     "name_norm": "Astonishing Speed",
     "octgn": "51223bd0-ffd1-11df-a976-0801206c9003",
-    "categories": ""
+    "categories": "Willpower Bonus"
   },
   {
     "name": "Mirkwood Runner",
@@ -2824,7 +2824,7 @@
     "textc": "Action: Choose a Dwarf hero. That hero gets +2 Willpower, +2 Attack, and +2 Defense until the end of the round.",
     "name_norm": "Durin's Song",
     "octgn": "51223bd0-ffd1-11df-a976-0801207c9024",
-    "categories": "Attack Bonus, Defense Bonus"
+    "categories": "Attack Bonus, Defense Bonus, Willpower Bonus"
   },
   {
     "name": "Ever Onward",
@@ -2942,7 +2942,7 @@
     "textc": "Action: Each Dwarf character gets +1 Willpower until the end of the phase. (+2 Willpower instead if the active location is an Underground or Dark location.)",
     "name_norm": "Untroubled by Darkness",
     "octgn": "51223bd0-ffd1-11df-a976-0801207c9083",
-    "categories": ""
+    "categories": "Willpower Bonus"
   },
   {
     "name": "Erebor Record Keeper",
@@ -2982,7 +2982,7 @@
     "textc": "Action: Exhaust a Dwarf character to place 2 progress tokens on the active location. (4 progress tokens instead if it is an Underground or Mountain location.)",
     "name_norm": "Ancestral Knowledge",
     "octgn": "51223bd0-ffd1-11df-a976-0801207c9007",
-    "categories": ""
+    "categories": "Location Control"
   },
   {
     "name": "Boots from Erebor",
@@ -3353,7 +3353,7 @@
     "textc": "Action: Exhaust Bombur to choose a location. That location gets -1 Threat until the end of the phase. (That location does not contribute its Threat instead if it is an Underground location.)",
     "name_norm": "Bombur",
     "octgn": "51223bd0-ffd1-11df-a976-0801209c9007",
-    "categories": ""
+    "categories": "Location Control"
   },
   {
     "name": "Out of the Wild",
@@ -3447,7 +3447,7 @@
     "textc": "Attach to a hero. Attached hero gains a Leadership resource icon.\nIf attached hero is Aragorn, each character you control gets +1 Willpower.",
     "name_norm": "Sword that was Broken",
     "octgn": "51223bd0-ffd1-11df-a976-0801210c9018",
-    "categories": "Resource Smoothing"
+    "categories": "Resource Smoothing, Willpower Bonus"
   },
   {
     "name": "Watcher of the Bruinen",
@@ -3527,7 +3527,7 @@
     "textc": "Action: If you control a unique Noldor character, give another character +1 Willpower until the end of the phase and lower your threat by 3.",
     "name_norm": "Elrond's Counsel",
     "octgn": "51223bd0-ffd1-11df-a976-0801210c9005",
-    "categories": "Threat Control"
+    "categories": "Threat Control, Willpower Bonus"
   },
   {
     "name": "Short Cut",
@@ -3545,7 +3545,7 @@
     "textc": "Response: After a location enters play, exhaust a Hobbit character to shuffle that location back into the encounter deck. Then, reveal 1 card from the encounter deck and add it to the staging area.",
     "name_norm": "Short Cut",
     "octgn": "51223bd0-ffd1-11df-a976-0801210c9014",
-    "categories": ""
+    "categories": "Location Control"
   },
   {
     "name": "Legacy of Durin",
@@ -3824,7 +3824,7 @@
     "textc": "Response: After Longbeard Elder commits to a quest, look at the top card of the encounter deck. If that card is a location, place 1 progress token on the current quest. Otherwise, Longbeard Elder gets -1 Willpower until the end of the phase.",
     "name_norm": "Longbeard Elder",
     "octgn": "51223bd0-ffd1-11df-a976-0801212c9021",
-    "categories": ""
+    "categories": "Location Control"
   },
   {
     "name": "Path of Need",
@@ -3981,7 +3981,7 @@
     "textc": "Attach to a Noldor or Silvan hero.\nAction: Exhaust Asfaloth to place 1 progress token on any location. (2 tokens instead if attached hero is Glorfindel.)",
     "name_norm": "Asfaloth",
     "octgn": "51223bd0-ffd1-11df-a976-0801212c9001",
-    "categories": ""
+    "categories": "Location Control"
   },
   {
     "name": "Elrond",
@@ -4058,7 +4058,7 @@
     "textc": "Action: Exhaust a character you control with ranged to immediately declare it as an attacker (and resolve its attack) against an enemy in the staging area. It gets +1 Attack during this attack.",
     "name_norm": "Hands Upon the Bow",
     "octgn": "51223bd0-ffd1-11df-a976-0801213c9007",
-    "categories": "Attack Bonus"
+    "categories": "Attack Bonus, Staging Area Attack"
   },
   {
     "name": "O Elbereth! Gilthonial!",
@@ -4094,7 +4094,7 @@
     "textc": "Attach to a hero.\nAction: Discard Miruvor to (choose two): ready attached hero, add 1 resource to attached hero's resource pool, attached hero gets +1 Willpower until the end of the round, or put Miruvor on the top of your deck.",
     "name_norm": "Miruvor",
     "octgn": "51223bd0-ffd1-11df-a976-0801213c9016",
-    "categories": "Readying, Resource Acceleration"
+    "categories": "Readying, Resource Acceleration, Willpower Bonus"
   },
   {
     "name": "Master of the Forge",
@@ -4675,7 +4675,7 @@
     "textc": "Each Outlands character you control gets +1 Willpower.",
     "name_norm": "Ethir Swordsman",
     "octgn": "1c149f93-9e3b-42fa-878c-80b29563a283",
-    "categories": ""
+    "categories": "Willpower Bonus"
   },
   {
     "name": "Ring of Barahir",
@@ -5144,7 +5144,7 @@
     "textc": "Play Ithilien Pit into the staging area unattached.\n\nIf unattached, attach Ithilien Pit to the next eligible enemy that enters the staging area.\n\nAny character may choose attached enemy as the target of an attack.",
     "name_norm": "Ithilien Pit",
     "octgn": "fd89bdbf-7475-4f3e-96fc-8f5315a90029",
-    "categories": ""
+    "categories": "Staging Area Attack"
   },
   {
     "name": "Hobbit-sense",
@@ -5246,7 +5246,7 @@
     "textc": "If each of your heroes has a printed Tactics resource icon, Knight of Minas Tirith gains: `Response: After Knight of Minas Tirith enters play, choose an enemy in the staging area. Engage that enemy and exhaust Knight of Minas Tirith to declare it as attacker (and resolve its attack) against that enemy.`",
     "name_norm": "Knight of Minas Tirith",
     "octgn": "237b31e7-d0b0-4c1e-bd4a-40a175f7d7d1",
-    "categories": ""
+    "categories": "Staging Area Attack"
   },
   {
     "name": "Gondorian Fire",
@@ -5287,7 +5287,7 @@
     "textc": "Pelargir Shipwright gets +1 Willpower for each hero you control with a printed Spirit resource icon.",
     "name_norm": "Pelargir Shipwright",
     "octgn": "d8d1e7b4-3639-4ca0-bc83-daa7f78554b2",
-    "categories": ""
+    "categories": "Willpower Bonus"
   },
   {
     "name": "Map of Earnil",
@@ -5324,7 +5324,7 @@
     "textc": "Restricted.\nAttach to a Ranger character.\nAction: Exhaust Ranger Bow and attached character to deal 1 damage to an enemy in the staging area.",
     "name_norm": "Ranger Bow",
     "octgn": "3fa0b17f-a7d1-4f0c-a779-c20cb6084e78",
-    "categories": "Direct Damage"
+    "categories": "Direct Damage, Staging Area Attack"
   },
   {
     "name": "Forest Patrol",
@@ -5507,7 +5507,7 @@
     "textc": "Action: Choose a Silvan or Noldor ally you control. That ally gets +2 Willpower until the end of the phase. At the end of the phase, shuffle that ally into its owner's deck if it is still in play.",
     "name_norm": "Children of the Sea",
     "octgn": "65d3b334-df93-43c6-9525-12674bbb7f06",
-    "categories": ""
+    "categories": "Willpower Bonus"
   },
   {
     "name": "Anborn",
@@ -5590,7 +5590,7 @@
     "textc": "Sentinel.\nEach hero with a printed Tactics resource icon gets +1 Willpower.",
     "name_norm": "Theoden",
     "octgn": "29d5feef-6165-4077-bb80-692526a8a924",
-    "categories": ""
+    "categories": "Willpower Bonus"
   },
   {
     "name": "Pelargir Ship Captain",
@@ -5631,7 +5631,7 @@
     "textc": "Attach to a Gondor hero.\nWhile attached hero has at least 1 resource in its resource pool, Gondor characters get +1 Willpower.",
     "name_norm": "Visionary Leadership",
     "octgn": "2f0a3f18-c84f-4458-b6f7-2e6be9acee6b",
-    "categories": ""
+    "categories": "Willpower Bonus"
   },
   {
     "name": "Spear of the Mark",
@@ -5707,7 +5707,7 @@
     "textc": "Action: Choose a Spirit hero. Until the end of the phase, that hero gets +1 Willpower for each resource in its resource pool.",
     "name_norm": "Lay of Nimrodel",
     "octgn": "b442354c-887d-403e-815b-a11f10a8760d",
-    "categories": ""
+    "categories": "Willpower Bonus"
   },
   {
     "name": "Ered Nimrais Prospector",
@@ -5880,7 +5880,7 @@
     "textc": "Response: After you raise your threat from the Doomed keyword, Isengard Messenger gets +1 Willpower until the end of the round. (Limit twice per round.)",
     "name_norm": "Isengard Messenger",
     "octgn": "fe60620b-9ea1-4bf8-8d41-e7fd81a28427",
-    "categories": ""
+    "categories": "Willpower Bonus"
   },
   {
     "name": "Westfold Outrider",
@@ -6101,7 +6101,7 @@
     "textc": "Response: After a Silvan ally enters play, that ally gets +1 Willpower, +1 Attack and +1 Defense until the end of the round.",
     "name_norm": "Celeborn",
     "octgn": "4c4cccd3-576a-41f1-8b6c-ba11b4cc3d4b",
-    "categories": "Attack Bonus, Defense Bonus"
+    "categories": "Attack Bonus, Defense Bonus, Willpower Bonus"
   },
   {
     "name": "Naith Guide",
@@ -6413,7 +6413,7 @@
     "textc": "You may give Greyflood Wanderer doomed 2 when you play from your hand. If you do, it gains: `Response: After you play Greyflood Wanderer, place 1 progress token on each location in play.`",
     "name_norm": "Greyflood Wanderer",
     "octgn": "284838f8-1ea0-466f-a373-032c7ad6e836",
-    "categories": ""
+    "categories": "Location Control"
   },
   {
     "name": "Warden of Arnor",
@@ -6432,7 +6432,7 @@
     "textc": "Attach to a Scout hero.\nWhile attached character is committed to the quest, place 1 progress on the first location revealed by the encounter deck each round.",
     "name_norm": "Warden of Arnor",
     "octgn": "f9b39223-3b12-4682-8db5-9ef4116b4919",
-    "categories": ""
+    "categories": "Location Control"
   },
   {
     "name": "Message from Elrond",
@@ -6512,7 +6512,7 @@
     "textc": "Ranged.\nCombat Action: If you have not engaged an enemy this round, exhaust Haldir of L\u00f3rien to declare him as an attacker (and resolve his attack) against an enemy not engaged with you. Limit once per round.",
     "name_norm": "Haldir of Lorien",
     "octgn": "9d548a43-0ef8-45e6-ab95-7356d218d203",
-    "categories": ""
+    "categories": "Staging Area Attack"
   },
   {
     "name": "Herald of An\u00f3rien",
@@ -6615,7 +6615,7 @@
     "textc": "Action: Choose a hero. That hero gets +2 Willpower until the end of the phase. Then, if your threat is 20 or less and this is the first time you played a copy of Courage Awakened this round, return this card to your hand instead of discarding it.",
     "name_norm": "Courage Awakened",
     "octgn": "72ec977b-6d24-459c-aaa8-49c2a01f0766",
-    "categories": "Secrecy"
+    "categories": "Secrecy, Willpower Bonus"
   },
   {
     "name": "Free to Choose",
@@ -7113,7 +7113,7 @@
     "textc": "Attach to Galadriel. She gains a Lore resource icon.\nQuest Action: Exhaust Nenya and Galadriel to add her Willpower to another character's Willpower until the end of the phase.",
     "name_norm": "Nenya",
     "octgn": "17ed9b53-19f5-4ad1-ab91-14c2859e5a60",
-    "categories": "Resource Smoothing"
+    "categories": "Resource Smoothing, Willpower Bonus"
   },
   {
     "name": "Erkenbrand",
@@ -7455,7 +7455,7 @@
     "textc": "Warden of Ann\u00faminas gets +1 Willpower for each enemy engaged with you.",
     "name_norm": "Warden of Annuminas",
     "octgn": "a933917f-4c7e-416e-8b08-ee2e60f6ab5f",
-    "categories": ""
+    "categories": "Willpower Bonus"
   },
   {
     "name": "Ranger Summons",
@@ -7512,7 +7512,7 @@
     "textc": "Response: After you engage an enemy, exhaust a Scout or Ranger character to place X progress tokens on a location. X is the engaged enemy's printed Threat.",
     "name_norm": "Expert Trackers",
     "octgn": "86583668-7581-4bca-ba10-a4752878740e",
-    "categories": ""
+    "categories": "Location Control"
   },
   {
     "name": "Heir of Valandil",
@@ -7588,7 +7588,7 @@
     "textc": "Attach to a D\u00fanedain or Noldor hero. Limit 1 per hero.\nWhile you are engaged with an enemy, attached hero gets +1 Willpower and cannot have its Willpower reduced.",
     "name_norm": "Star Brooch",
     "octgn": "130df5c3-a050-4690-8dac-d1ae937a2e3c",
-    "categories": ""
+    "categories": "Willpower Bonus"
   },
   {
     "name": "Gather Information",
@@ -7630,7 +7630,7 @@
     "textc": "Encounter. Surge. Ranged. Sentinel.\nWhen Revealed: The first player chooses a player to take control of Ranger of the North. Then either deal 2 damage to an enemy or place 2 progress tokens on a location.",
     "name_norm": "ZZ_Ranger of the North",
     "octgn": "156ed210-ab6e-4da9-b8c0-48984711edf2",
-    "categories": "Direct Damage"
+    "categories": "Direct Damage, Location Control"
   },
   {
     "name": "Merry",
@@ -7676,7 +7676,7 @@
     "textc": "Ingold gets +1 Willpower for each hero you control with at least 1 resource in its resource pool.",
     "name_norm": "Ingold",
     "octgn": "1e28318c-e82a-4d50-b6db-d08e6e9a6b53",
-    "categories": ""
+    "categories": "Willpower Bonus"
   },
   {
     "name": "Rallying Cry",
@@ -7800,7 +7800,7 @@
     "textc": "East Road Ranger gets +2 Willpower while committed to a side quest.",
     "name_norm": "East Road Ranger",
     "octgn": "8b95d0c6-eda4-4820-8279-6bdddae7b499",
-    "categories": ""
+    "categories": "Willpower Bonus"
   },
   {
     "name": "Scout Ahead",
@@ -7865,7 +7865,7 @@
     "textc": "If the active location shares a Trait with a location in the victory display, Rossiel gets +2 Willpower.\n If the attacking enemy shares a Trait with an enemy in the victory display, Rossiel gets +2 Defense.",
     "name_norm": "Rossiel",
     "octgn": "18fea279-cd38-4a5e-b271-b94d4f64eda1",
-    "categories": "Defense Bonus"
+    "categories": "Defense Bonus, Willpower Bonus"
   },
   {
     "name": "Veteran of Osgiliath",
@@ -7888,7 +7888,7 @@
     "textc": "Veteran of Osgiliath gets +1 Willpower, +1 Attack, and +1 Defense while your threat is 40 or higher.",
     "name_norm": "Veteran of Osgiliath",
     "octgn": "0484e428-6a72-4841-b2d5-d8df7cfb51bf",
-    "categories": "Defense Bonus"
+    "categories": "Defense Bonus, Willpower Bonus"
   },
   {
     "name": "Descendants of Kings",
@@ -8028,7 +8028,7 @@
     "textc": "Action: Exhaust a Ranger or Scout character to discard a non-unique active location. Then, search the encounter deck and discard pile for a non-unique location and make it the active location. Shuffle the encounter deck.",
     "name_norm": "Distant Stars",
     "octgn": "3ba15db9-9967-48b8-9b38-4fdfb4866676",
-    "categories": ""
+    "categories": "Location Control"
   },
   {
     "name": "Keen as Lances",
@@ -8168,7 +8168,7 @@
     "textc": "Attach to a Spirit or Noldor hero. Restricted.\nResponse: After attached hero commits to a quest, discard a card from your hand to place 2 progress on the active location.",
     "name_norm": "Steed of Imladris",
     "octgn": "8741c7a7-be7d-462a-b39a-0c9bfe4042a3",
-    "categories": ""
+    "categories": "Location Control"
   },
   {
     "name": "Fair and Perilous",
@@ -8187,7 +8187,7 @@
     "textc": "Action: Choose a Noldor or Silvan character. Until the end of the phase, add that character's Willpower to its Attack.",
     "name_norm": "Fair and Perilous",
     "octgn": "475d185f-403f-4b3e-9e8b-6b9f539c2423",
-    "categories": ""
+    "categories": "Willpower Bonus"
   },
   {
     "name": "Wellinghall Preserver",
@@ -8582,7 +8582,7 @@
     "textc": "Lords of the Eldar can only be played from your discard pile.\nAction: Place Lords of the Eldar on the bottom of your deck from your discard pile. Then, until the end of the round all Noldor characters get +1 Willpower, +1 Attack, and +1 Defense.",
     "name_norm": "Lords of the Eldar",
     "octgn": "ff265d76-021b-4f23-9e62-a57e16b3e77d",
-    "categories": "Attack Bonus, Defense Bonus"
+    "categories": "Attack Bonus, Defense Bonus, Willpower Bonus"
   },
   {
     "name": "The Long Defeat",
@@ -8774,7 +8774,7 @@
     "textc": "Action: Exhaust a Noldor character to ready a D\u00fanedain character, or vice-versa. Until the end of the phase, add the exhausted character's printed Willpower to the other character's Willpower, Attack, and Defense.",
     "name_norm": "Tale of Tinuviel",
     "octgn": "4d71af80-33cd-4df8-b6da-c479c8a3ae74",
-    "categories": "Readying"
+    "categories": "Readying, Willpower Bonus"
   },
   {
     "name": "Galadhrim Healer",
@@ -8992,7 +8992,7 @@
     "textc": "Attach to a Leadership or a Scout character.\nResponse: At the beginning of the travel phase, exhaust Mariner's Compass and attached character to search the top 5 cards of the encounter deck for a location. Switch that location with a location in the staging area. Shuffle the encounter deck.",
     "name_norm": "Mariner's Compass",
     "octgn": "fe1a0aef-10bd-441b-a27b-0527810fef57",
-    "categories": ""
+    "categories": "Location Control"
   },
   {
     "name": "Lindon Navigator",
@@ -9032,7 +9032,7 @@
     "textc": "Action: Place 2 progress on any location. Resolve that effect again for each copy of The Evening Star currently in your discard pile (you may choose new targets).",
     "name_norm": "The Evening Star",
     "octgn": "b6729381-3bfc-41fa-abd1-99f410eb19b8",
-    "categories": ""
+    "categories": "Location Control"
   },
   {
     "name": "Explorer's Almanac",
@@ -9050,7 +9050,7 @@
     "textc": "Attach to a location in the staging area.\nProgress from questing successfully may be placed on the attached location before it is placed on the current quest.",
     "name_norm": "Explorer's Almanac",
     "octgn": "21f0acdb-5d11-409e-80f8-c717fab87ab9",
-    "categories": ""
+    "categories": "Location Control"
   },
   {
     "name": "Sailor of Lune",
@@ -9072,7 +9072,7 @@
     "textc": "While the top card of your discard pile is an event, Sailor of Lune gets +1 Willpower and gains: \"Cannot be damaged while committed to the quest.\"",
     "name_norm": "Sailor of Lune",
     "octgn": "85a269eb-63f1-4f63-83c9-30b718d364f6",
-    "categories": ""
+    "categories": "Willpower Bonus"
   },
   {
     "name": "Elwing's Flight",
@@ -9090,7 +9090,7 @@
     "textc": "Quest Action: Ready a questing character and give that character +1 Willpower until the end of the phase. Resolve that effect again for each copy of Elwing's Flight currently in your discard pile (you may choose different targets).",
     "name_norm": "Elwing's Flight",
     "octgn": "d25dfbee-85c4-42f8-9653-c0536d3e5095",
-    "categories": "Readying"
+    "categories": "Readying, Willpower Bonus"
   },
   {
     "name": "To the Sea, to the Sea!",
@@ -9514,7 +9514,7 @@
     "textc": "Action: Bilbo Baggins gets +2 Willpower, +2 Attack, and +2 Defense until the end of the phase. (You may spend a Baggins resource from Bilbo Baggins' resource pool to play this card even if you do not control Bilbo Baggins.)",
     "name_norm": "Burglar Baggins",
     "octgn": "51223bd0-ffd1-11df-a976-1801204c9020",
-    "categories": "Defense Bonus"
+    "categories": "Defense Bonus, Willpower Bonus"
   },
   {
     "name": "Bilbo Baggins",
@@ -9753,7 +9753,7 @@
     "textc": "Action: Exhaust a hero you control to shuffle the encounter deck and look at its top card. Place progress tokens on the current quest equal to the revealed card's Threat. Then, put that card back on top of the encounter deck.",
     "name_norm": "Ravens of the Mountain",
     "octgn": "6d442a61-e9e9-4729-bac1-da3d76af6afa",
-    "categories": ""
+    "categories": "Location Control"
   },
   {
     "name": "To me! O my kinsfolk!",
@@ -9790,7 +9790,7 @@
     "textc": "Action: Choose a character in play (other than Bilbo Baggins). Add Bilbo Baggins' total Willpower, Attack, and Defense to that character's Willpower, Attack, and Defense respectively until the end of the phase.",
     "name_norm": "The Lucky Number",
     "octgn": "65407141-e013-4d1c-8f70-4328e707d0cc",
-    "categories": ""
+    "categories": "Willpower Bonus"
   },
   {
     "name": "Great Yew Bow",
@@ -9808,7 +9808,7 @@
     "textc": "Restricted.\nAttach to a hero with printed Ranged keyword.\nCombat Action: Choose an enemy in the staging area. Exhaust Great Yew Bow and attached hero to make a ranged attack against that enemy. Declare attached hero as the attacker. No other attackers can be declared for this attack.",
     "name_norm": "Great Yew Bow",
     "octgn": "833664a0-6bab-4e93-b5f1-88e7b6456569",
-    "categories": ""
+    "categories": "Staging Area Attack"
   },
   {
     "name": "Black Arrow",
@@ -9847,7 +9847,7 @@
     "textc": "Attacht to a hero.\nResponse: After a location is added to the staging area, attach Thror's Key to that location. While attached to a location, Thror's Key gains: 'Treat attached location's printed text box as blank, except for traits.'",
     "name_norm": "Thror's Key",
     "octgn": "f4490261-317e-4e9e-9440-a5c58dcddcbf",
-    "categories": ""
+    "categories": "Location Control"
   },
   {
     "name": "Expert Treasure-hunter",
@@ -9930,7 +9930,7 @@
     "textc": "Response: After you engage an enemy with a higher engagement cost than your threat, ready Sam Gamgee. He gets +1 Willpower, +1 Attack and +1 Defense until the end of the round.",
     "name_norm": "Sam Gamgee",
     "octgn": "4124136c-8c86-4f86-830c-94c8c76df161",
-    "categories": "Defense Bonus"
+    "categories": "Defense Bonus, Willpower Bonus"
   },
   {
     "name": "Merry",
@@ -10087,7 +10087,7 @@
     "textc": "Action: Choose a Hobbit character. That character gets +2 Willpower, +2 Attack and +2 Defense until the end of the phase.",
     "name_norm": "Halfling Determination",
     "octgn": "8e7e5c8d-0ea4-46df-ae38-d8d2fee7ca8b",
-    "categories": "Attack Bonus, Defense Bonus"
+    "categories": "Attack Bonus, Defense Bonus, Willpower Bonus"
   },
   {
     "name": "Smoke Rings",
@@ -10106,7 +10106,7 @@
     "textc": "Action: Reduce your threat by 1 for each Pipe you control. Each hero with a Pipe attachment gets +1 Willpower until the end of the phase.",
     "name_norm": "Smoke Rings",
     "octgn": "9418c634-54c6-47de-9aae-798038a4a35b",
-    "categories": "Threat Control"
+    "categories": "Threat Control, Willpower Bonus"
   },
   {
     "name": "Take No Notice",
@@ -10144,7 +10144,7 @@
     "textc": "Action: Each hero you control gets +1 Willpower until the end of the round. Draw 1 card for each Hobbit hero you control.",
     "name_norm": "Frodo's Intuition",
     "octgn": "96350b97-5c68-4033-bb2f-4305696a7ae7",
-    "categories": ""
+    "categories": "Willpower Bonus"
   },
   {
     "name": "Hobbit Cloak",
@@ -10430,7 +10430,7 @@
     "textc": "Attach to the Ring-bearer.\nEach hero gets +1 Willpower.\nForced: After a character is destroyed, discard Fellowship of the Ring.",
     "name_norm": "Fellowship of the Ring",
     "octgn": "d5f09d24-be50-4958-b0d0-41b1ad09b7af",
-    "categories": ""
+    "categories": "Willpower Bonus"
   },
   {
     "name": "Aragorn",
@@ -10499,7 +10499,7 @@
     "textc": "Cannot have restricted attachments.\nAction: Deal 1 damage to Treebeard to give him +1 Willpower and +1 Attack until the end of the phase. (Limit 5 times per phase.)",
     "name_norm": "Treebeard",
     "octgn": "94f6738a-c946-4415-9b38-0ce3a443fa33",
-    "categories": ""
+    "categories": "Willpower Bonus"
   },
   {
     "name": "Gimli",
@@ -10610,7 +10610,7 @@
     "textc": "Attach to a hero or Legolas.\nResponse: After attached character participates in an attack that destroys an enemy, exhaust Arod to place 1 progress token on any location.",
     "name_norm": "Arod",
     "octgn": "6646bb07-0b44-4051-94a7-39c600b38481",
-    "categories": ""
+    "categories": "Location Control"
   },
   {
     "name": "Ent Draught",
@@ -10705,7 +10705,7 @@
     "textc": "Play only if you control Fellowship Aragorn.\nQuest Action: Choose 3 heroes committed to the quest. Ready those heroes. Until the end of the round, each of the chosen heroes gets +1 Willpower, +1 Attack, and +1 Defense.",
     "name_norm": "The Three Hunters",
     "octgn": "4101f975-3317-43f8-ba60-19785e01959c",
-    "categories": "Readying, Defense Bonus"
+    "categories": "Readying, Defense Bonus, Willpower Bonus"
   },
   {
     "name": "Shadowfax",
@@ -10747,7 +10747,7 @@
     "textc": "Action: Spend 1 Fellowship resource and exhaust The One Ring to give Frodo Baggins +2 Willpower and +2 Attack until the end of the round.",
     "name_norm": "Frodo Baggins",
     "octgn": "fe58a6d3-7028-41c1-ab00-5e33e7d77b5f",
-    "categories": ""
+    "categories": "Willpower Bonus"
   },
   {
     "name": "Faramir",

--- a/cards.json
+++ b/cards.json
@@ -13,16 +13,17 @@
     "no": 1,
     "img": "http://www.cardgamedb.com/forums/uploads/lotr/aragorn-core.jpg",
     "unique": true,
-    "traits": " Dúnedain. Noble. Ranger.",
+    "traits": " D\u00fanedain. Noble. Ranger.",
     "keywords": "Sentinel.",
     "text": "Response: After Aragorn commits to a quest, spend 1 resource from his resource pool to ready him.",
     "flavor": "`I am Aragorn son of Arathorn; and if by life or death I can save you, I will.` -The Fellowship of the Ring",
     "textc": "Sentinel.\nResponse: After Aragorn commits to a quest, spend 1 resource from his resource pool to ready him.",
     "name_norm": "Aragorn",
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9001"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9001",
+    "categories": "Readying"
   },
   {
-    "name": "Théodred",
+    "name": "Th\u00e9odred",
     "type": "1hero",
     "sphere": "1leadership",
     "cost": 8,
@@ -37,14 +38,15 @@
     "unique": true,
     "traits": " Noble. Rohan. Warrior.",
     "keywords": "",
-    "text": "Response: After Théodred commits to a quest, choose a hero committed to that quest. Add 1 resource to that hero's resource pool.",
-    "flavor": "`Not all is dark. Take courage, Lord of the Mark...`\r\n\r\n-Gandalf, The Two Towers",
-    "textc": "Response: After Théodred commits to a quest, choose a hero committed to that quest. Add 1 resource to that hero's resource pool.",
+    "text": "Response: After Th\u00e9odred commits to a quest, choose a hero committed to that quest. Add 1 resource to that hero's resource pool.",
+    "flavor": "`Not all is dark. Take courage, Lord of the Mark...`\n\n-Gandalf, The Two Towers",
+    "textc": "Response: After Th\u00e9odred commits to a quest, choose a hero committed to that quest. Add 1 resource to that hero's resource pool.",
     "name_norm": "Theodred",
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9002"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9002",
+    "categories": "Resource Acceleration"
   },
   {
-    "name": "Glóin",
+    "name": "Gl\u00f3in",
     "type": "1hero",
     "sphere": "1leadership",
     "cost": 9,
@@ -59,11 +61,11 @@
     "unique": true,
     "traits": " Dwarf. Noble.",
     "keywords": "",
-    "text": "Response: After Glóin suffers damage, add 1 resource to his resource pool for each point of damage he just suffered.",
-    "flavor": null,
-    "textc": "Response: After Glóin suffers damage, add 1 resource to his resource pool for each point of damage he just suffered.",
+    "text": "Response: After Gl\u00f3in suffers damage, add 1 resource to his resource pool for each point of damage he just suffered.",
+    "textc": "Response: After Gl\u00f3in suffers damage, add 1 resource to his resource pool for each point of damage he just suffered.",
     "name_norm": "Gloin",
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9003"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9003",
+    "categories": "Resource Acceleration"
   },
   {
     "name": "Gimli",
@@ -85,7 +87,8 @@
     "flavor": "`Men need many words before deeds. My axe is restless in my hands` -The Two Towers",
     "textc": "Gimli gets +1 Attack for each damage token on him.",
     "name_norm": "Gimli",
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9004"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9004",
+    "categories": "Attack Bonus"
   },
   {
     "name": "Legolas",
@@ -104,10 +107,10 @@
     "traits": " Noble. Silvan. Warrior.",
     "keywords": "Ranged.",
     "text": "Response: After Legolas participates in an attack that destroys an enemy, place 2 progress tokens on the current quest.",
-    "flavor": null,
     "textc": "Ranged.\nResponse: After Legolas participates in an attack that destroys an enemy, place 2 progress tokens on the current quest.",
     "name_norm": "Legolas",
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9005"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9005",
+    "categories": ""
   },
   {
     "name": "Thalin",
@@ -126,13 +129,13 @@
     "traits": " Dwarf. Warrior.",
     "keywords": "",
     "text": "While Thalin is committed to a quest, deal 1 damage to each enemy as it is revealed by the encounter deck.",
-    "flavor": null,
     "textc": "While Thalin is committed to a quest, deal 1 damage to each enemy as it is revealed by the encounter deck.",
     "name_norm": "Thalin",
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9006"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9006",
+    "categories": "Direct Damage"
   },
   {
-    "name": "Éowyn",
+    "name": "\u00c9owyn",
     "type": "1hero",
     "sphere": "3spirit",
     "cost": 9,
@@ -147,11 +150,11 @@
     "unique": true,
     "traits": " Noble. Rohan.",
     "keywords": "",
-    "text": "Action: Discard 1 card from your hand to give Éowyn +1 Willpower until the end of the phase. This effect may be triggered by each player once each round.",
-    "flavor": null,
-    "textc": "Action: Discard 1 card from your hand to give Éowyn +1 Willpower until the end of the phase. This effect may be triggered by each player once each round.",
+    "text": "Action: Discard 1 card from your hand to give \u00c9owyn +1 Willpower until the end of the phase. This effect may be triggered by each player once each round.",
+    "textc": "Action: Discard 1 card from your hand to give \u00c9owyn +1 Willpower until the end of the phase. This effect may be triggered by each player once each round.",
     "name_norm": "Eowyn",
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9007"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9007",
+    "categories": ""
   },
   {
     "name": "Eleanor",
@@ -170,13 +173,13 @@
     "traits": " Gondor. Noble.",
     "keywords": "",
     "text": "Response: Exhaust Eleanor to cancel the 'when revealed' effects of a treachery card just revealed by the encounter deck. Then, discard that card, and replace it with the next card from the encounter deck.",
-    "flavor": null,
     "textc": "Response: Exhaust Eleanor to cancel the 'when revealed' effects of a treachery card just revealed by the encounter deck. Then, discard that card, and replace it with the next card from the encounter deck.",
     "name_norm": "Eleanor",
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9008"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9008",
+    "categories": ""
   },
   {
-    "name": "Dúnhere",
+    "name": "D\u00fanhere",
     "type": "1hero",
     "sphere": "3spirit",
     "cost": 8,
@@ -191,11 +194,11 @@
     "unique": true,
     "traits": " Rohan. Warrior.",
     "keywords": "",
-    "text": "Dúnhere can target enemies in the staging area when he attacks alone. When doing so, he gets +1 Attack.",
-    "flavor": null,
-    "textc": "Dúnhere can target enemies in the staging area when he attacks alone. When doing so, he gets +1 Attack.",
+    "text": "D\u00fanhere can target enemies in the staging area when he attacks alone. When doing so, he gets +1 Attack.",
+    "textc": "D\u00fanhere can target enemies in the staging area when he attacks alone. When doing so, he gets +1 Attack.",
     "name_norm": "Dunhere",
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9009"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9009",
+    "categories": "Attack Bonus"
   },
   {
     "name": "Denethor",
@@ -214,10 +217,10 @@
     "traits": " Gondor. Noble. Steward.",
     "keywords": "",
     "text": "Action: Exhaust Denethor to look at the top card of the encounter deck. You may move that card to the bottom of the deck.",
-    "flavor": null,
     "textc": "Action: Exhaust Denethor to look at the top card of the encounter deck. You may move that card to the bottom of the deck.",
     "name_norm": "Denethor",
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9010"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9010",
+    "categories": ""
   },
   {
     "name": "Glorfindel",
@@ -236,10 +239,10 @@
     "traits": " Noble. Noldor. Warrior.",
     "keywords": "",
     "text": "Action: Pay 1 resource from Glorfindel's pool to heal 1 damage on any character. (Limit once per round.)",
-    "flavor": null,
     "textc": "Action: Pay 1 resource from Glorfindel's pool to heal 1 damage on any character. (Limit once per round.)",
     "name_norm": "Glorfindel",
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9011"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9011",
+    "categories": "Healing"
   },
   {
     "name": "Beravor",
@@ -255,13 +258,13 @@
     "no": 12,
     "img": "http://www.cardgamedb.com/forums/uploads/lotr/beravor-core.jpg",
     "unique": true,
-    "traits": " Dúnedain. Ranger.",
+    "traits": " D\u00fanedain. Ranger.",
     "keywords": "",
     "text": "Action: Exhaust Beravor to choose a player. That player draws 2 cards. Limit once per round.",
-    "flavor": null,
     "textc": "Action: Exhaust Beravor to choose a player. That player draws 2 cards. Limit once per round.",
     "name_norm": "Beravor",
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9012"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9012",
+    "categories": "Card Draw"
   },
   {
     "name": "Guard of the Citadel",
@@ -280,11 +283,11 @@
     "traits": " Gondor. Warrior.",
     "keywords": "",
     "text": "",
-    "flavor": null,
     "textc": "",
     "name_norm": "Guard of the Citadel",
     "corequantity": 3,
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9013"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9013",
+    "categories": ""
   },
   {
     "name": "Faramir",
@@ -303,11 +306,11 @@
     "traits": " Gondor. Noble. Ranger.",
     "keywords": "",
     "text": "Action: Exhaust Faramir to choose a player. Each character controlled by that player gets +1 Willpower until the end of the phase.",
-    "flavor": null,
     "textc": "Action: Exhaust Faramir to choose a player. Each character controlled by that player gets +1 Willpower until the end of the phase.",
     "name_norm": "Faramir",
     "corequantity": 2,
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9014"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9014",
+    "categories": ""
   },
   {
     "name": "Son of Arnor",
@@ -323,14 +326,15 @@
     "no": 15,
     "img": "http://www.cardgamedb.com/forums/uploads/lotr/son-of-arnor-core.jpg",
     "unique": false,
-    "traits": " Dúnedain.",
+    "traits": " D\u00fanedain.",
     "keywords": "",
     "text": "Response: After Son of Arnor enters play, choose an enemy card in the staging area or currently engaged with another player. Engage that enemy.",
     "flavor": "...and the North-realm they made in Arnor, and the South-realm in Gondor above the mouths of Anduin. -The Fellowship of the Ring",
     "textc": "Response: After Son of Arnor enters play, choose an enemy card in the staging area or currently engaged with another player. Engage that enemy.",
     "name_norm": "Son of Arnor",
     "corequantity": 2,
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9015"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9015",
+    "categories": ""
   },
   {
     "name": "Snowbourn Scout",
@@ -353,7 +357,8 @@
     "textc": "Response: After Snowbourn Scout enters play, choose a location. Place 1 progress token on that location.",
     "name_norm": "Snowbourn Scout",
     "corequantity": 3,
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9016"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9016",
+    "categories": ""
   },
   {
     "name": "Silverlode Archer",
@@ -372,11 +377,12 @@
     "traits": " Archer. Silvan.",
     "keywords": "Ranged.",
     "text": "",
-    "flavor": "`We have been keeping watch on the rivers, ever since we saw a great troop of Orcs going north towards Moria, along the skirts of the mountains, many days ago.` -Haldir of Lórien, The Fellowship of the Ring",
+    "flavor": "`We have been keeping watch on the rivers, ever since we saw a great troop of Orcs going north towards Moria, along the skirts of the mountains, many days ago.` -Haldir of L\u00f3rien, The Fellowship of the Ring",
     "textc": "Ranged.\n",
     "name_norm": "Silverlode Archer",
     "corequantity": 2,
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9017"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9017",
+    "categories": ""
   },
   {
     "name": "Longbeard Orc Slayer",
@@ -395,11 +401,11 @@
     "traits": " Dwarf. Warrior.",
     "keywords": "",
     "text": "Response: After Longbeard Orc Slayer enters play, deal 1 damage to each Orc enemy in play.",
-    "flavor": null,
     "textc": "Response: After Longbeard Orc Slayer enters play, deal 1 damage to each Orc enemy in play.",
     "name_norm": "Longbeard Orc Slayer",
     "corequantity": 2,
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9018"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9018",
+    "categories": "Direct Damage"
   },
   {
     "name": "Brok Ironfist",
@@ -418,11 +424,11 @@
     "traits": " Dwarf. Warrior.",
     "keywords": "",
     "text": "Response: After a Dwarf hero you control leaves play, put Brok Ironfist into play from your hand.",
-    "flavor": null,
     "textc": "Response: After a Dwarf hero you control leaves play, put Brok Ironfist into play from your hand.",
     "name_norm": "Brok Ironfist",
     "corequantity": 1,
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9019"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9019",
+    "categories": ""
   },
   {
     "name": "Veteran Axehand",
@@ -441,11 +447,11 @@
     "traits": " Dwarf. Warrior.",
     "keywords": "",
     "text": "",
-    "flavor": null,
     "textc": "",
     "name_norm": "Veteran Axehand",
     "corequantity": 3,
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9028"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9028",
+    "categories": ""
   },
   {
     "name": "Gondorian Spearman",
@@ -464,11 +470,11 @@
     "traits": " Gondor. Warrior.",
     "keywords": "Sentinel.",
     "text": "Response: After Gondorian Spearman is declared as a defender, deal 1 damage to the attacking enemy.",
-    "flavor": null,
     "textc": "Sentinel.\nResponse: After Gondorian Spearman is declared as a defender, deal 1 damage to the attacking enemy.",
     "name_norm": "Gondorian Spearman",
     "corequantity": 3,
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9029"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9029",
+    "categories": "Direct Damage"
   },
   {
     "name": "Horseback Archer",
@@ -487,11 +493,11 @@
     "traits": " Rohan. Archer.",
     "keywords": "Ranged.",
     "text": "",
-    "flavor": null,
     "textc": "Ranged.\n",
     "name_norm": "Horseback Archer",
     "corequantity": 2,
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9030"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9030",
+    "categories": ""
   },
   {
     "name": "Beorn",
@@ -510,11 +516,11 @@
     "traits": " Beorning. Warrior.",
     "keywords": "",
     "text": "Action: Beorn gains +5 Attack until the end of the phase. At the end of the phase in which you trigger this effect, shuffle Beorn back into your deck. (Limit once per round.)",
-    "flavor": null,
     "textc": "Action: Beorn gains +5 Attack until the end of the phase. At the end of the phase in which you trigger this effect, shuffle Beorn back into your deck. (Limit once per round.)",
     "name_norm": "Beorn",
     "corequantity": 1,
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9031"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9031",
+    "categories": "Attack Bonus"
   },
   {
     "name": "Wandering Took",
@@ -533,14 +539,14 @@
     "traits": " Hobbit.",
     "keywords": "",
     "text": "Action: Reduce your threat by 3 to give control of Wandering Took to another player. Raise that player's threat by 3.",
-    "flavor": null,
     "textc": "Action: Reduce your threat by 3 to give control of Wandering Took to another player. Raise that player's threat by 3.",
     "name_norm": "Wandering Took",
     "corequantity": 2,
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9043"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9043",
+    "categories": "Threat Control"
   },
   {
-    "name": "Lórien Guide",
+    "name": "L\u00f3rien Guide",
     "type": "2ally",
     "sphere": "3spirit",
     "cost": 3,
@@ -555,12 +561,12 @@
     "unique": false,
     "traits": " Silvan. Scout.",
     "keywords": "",
-    "text": "Response: After Lórien Guide commits to a quest, place 1 progress token on the active location.",
-    "flavor": null,
-    "textc": "Response: After Lórien Guide commits to a quest, place 1 progress token on the active location.",
+    "text": "Response: After L\u00f3rien Guide commits to a quest, place 1 progress token on the active location.",
+    "textc": "Response: After L\u00f3rien Guide commits to a quest, place 1 progress token on the active location.",
     "name_norm": "Lorien Guide",
     "corequantity": 3,
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9044"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9044",
+    "categories": ""
   },
   {
     "name": "Northern Tracker",
@@ -576,14 +582,15 @@
     "no": 45,
     "img": "http://www.cardgamedb.com/forums/uploads/lotr/northern-tracker-core.jpg",
     "unique": false,
-    "traits": " Dúnedain. Ranger.",
+    "traits": " D\u00fanedain. Ranger.",
     "keywords": "",
     "text": "Response: After Northern Tracker commits to a quest, place 1 progress token on each location in the staging area.",
-    "flavor": "`What roads would any dare to tread, what safety would there be in quiet lands, or in the homes of simple men at night, if the Dúnedain were asleep, or were all gone into the grave?` -Aragorn, The Fellowship of the Ring",
+    "flavor": "`What roads would any dare to tread, what safety would there be in quiet lands, or in the homes of simple men at night, if the D\u00fanedain were asleep, or were all gone into the grave?` -Aragorn, The Fellowship of the Ring",
     "textc": "Response: After Northern Tracker commits to a quest, place 1 progress token on each location in the staging area.",
     "name_norm": "Northern Tracker",
     "corequantity": 2,
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9045"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9045",
+    "categories": ""
   },
   {
     "name": "Daughter of the Nimrodel",
@@ -602,11 +609,11 @@
     "traits": " Silvan.",
     "keywords": "",
     "text": "Action: Exhaust Daughter of the Nimrodel to heal up to 2 damage on any 1 hero.",
-    "flavor": null,
     "textc": "Action: Exhaust Daughter of the Nimrodel to heal up to 2 damage on any 1 hero.",
     "name_norm": "Daughter of the Nimrodel",
     "corequantity": 3,
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9058"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9058",
+    "categories": "Healing"
   },
   {
     "name": "Erebor Hammersmith",
@@ -625,11 +632,11 @@
     "traits": " Dwarf. Craftsman.",
     "keywords": "",
     "text": "Response: After you play Erebor Hammersmith, return the topmost attachment in any player's discard pile to his hand.",
-    "flavor": null,
     "textc": "Response: After you play Erebor Hammersmith, return the topmost attachment in any player's discard pile to his hand.",
     "name_norm": "Erebor Hammersmith",
     "corequantity": 2,
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9059"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9059",
+    "categories": ""
   },
   {
     "name": "Henamarth Riversong",
@@ -648,11 +655,11 @@
     "traits": " Silvan.",
     "keywords": "",
     "text": "Action: Exhaust Henamarth Riversong to look at the top card of the encounter deck.",
-    "flavor": null,
     "textc": "Action: Exhaust Henamarth Riversong to look at the top card of the encounter deck.",
     "name_norm": "Henamarth Riversong",
     "corequantity": 1,
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9060"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9060",
+    "categories": ""
   },
   {
     "name": "Miner of the Iron Hills",
@@ -671,14 +678,14 @@
     "traits": " Dwarf.",
     "keywords": "",
     "text": "Response: After Miner of the Iron Hills enters play, choose and discard 1 Condition attachment from play.",
-    "flavor": null,
     "textc": "Response: After Miner of the Iron Hills enters play, choose and discard 1 Condition attachment from play.",
     "name_norm": "Miner of the Iron Hills",
     "corequantity": 2,
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9061"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9061",
+    "categories": "Condition Control"
   },
   {
-    "name": "Gléowine",
+    "name": "Gl\u00e9owine",
     "type": "2ally",
     "sphere": "4lore",
     "cost": 2,
@@ -693,12 +700,12 @@
     "unique": true,
     "traits": " Minstrel. Rohan.",
     "keywords": "",
-    "text": "Action: Exhaust Gléowine to choose a player. That player draws 1 card.",
-    "flavor": null,
-    "textc": "Action: Exhaust Gléowine to choose a player. That player draws 1 card.",
+    "text": "Action: Exhaust Gl\u00e9owine to choose a player. That player draws 1 card.",
+    "textc": "Action: Exhaust Gl\u00e9owine to choose a player. That player draws 1 card.",
     "name_norm": "Gleowine",
     "corequantity": 2,
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9062"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9062",
+    "categories": "Card Draw"
   },
   {
     "name": "Ever Vigilant",
@@ -713,11 +720,11 @@
     "traits": "",
     "keywords": "",
     "text": "Action: Choose and ready 1 ally card.",
-    "flavor": null,
     "textc": "Action: Choose and ready 1 ally card.",
     "name_norm": "Ever Vigilant",
     "corequantity": 2,
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9020"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9020",
+    "categories": "Readying"
   },
   {
     "name": "Common Cause",
@@ -732,11 +739,11 @@
     "traits": "",
     "keywords": "",
     "text": "Action: Exhaust 1 hero you control to choose and ready a different hero.",
-    "flavor": null,
     "textc": "Action: Exhaust 1 hero you control to choose and ready a different hero.",
     "name_norm": "Common Cause",
     "corequantity": 2,
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9021"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9021",
+    "categories": "Readying"
   },
   {
     "name": "For Gondor!",
@@ -751,11 +758,11 @@
     "traits": "",
     "keywords": "",
     "text": "Action: Until the end of the phase, all characters get +1 Attack. All Gondor characters also get +1 Defense until the end of the phase.",
-    "flavor": null,
     "textc": "Action: Until the end of the phase, all characters get +1 Attack. All Gondor characters also get +1 Defense until the end of the phase.",
     "name_norm": "For Gondor",
     "corequantity": 2,
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9022"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9022",
+    "categories": "Attack Bonus, Defense Bonus"
   },
   {
     "name": "Sneak Attack",
@@ -770,11 +777,11 @@
     "traits": "",
     "keywords": "",
     "text": "Action: Put 1 ally card into play from your hand. At the end of the phase, if that ally is still in play, return it to your hand.",
-    "flavor": null,
     "textc": "Action: Put 1 ally card into play from your hand. At the end of the phase, if that ally is still in play, return it to your hand.",
     "name_norm": "Sneak Attack",
     "corequantity": 2,
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9023"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9023",
+    "categories": ""
   },
   {
     "name": "Valiant Sacrifice",
@@ -789,11 +796,11 @@
     "traits": "",
     "keywords": "",
     "text": "Response: After an ally card leaves play, that card's controller draws 2 cards.",
-    "flavor": null,
     "textc": "Response: After an ally card leaves play, that card's controller draws 2 cards.",
     "name_norm": "Valiant Sacrifice",
     "corequantity": 2,
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9024"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9024",
+    "categories": "Card Draw"
   },
   {
     "name": "Grim Resolve",
@@ -808,11 +815,11 @@
     "traits": "",
     "keywords": "",
     "text": "Action: Ready all character cards in play.",
-    "flavor": null,
     "textc": "Action: Ready all character cards in play.",
     "name_norm": "Grim Resolve",
     "corequantity": 1,
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9025"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9025",
+    "categories": "Readying"
   },
   {
     "name": "Steward of Gondor",
@@ -831,10 +838,11 @@
     "textc": "Attach to a hero. Attached hero gains the Gondor trait.\nAction: Exhaust Steward of Gondor to add 2 resources to attached hero's resource pool.",
     "name_norm": "Steward of Gondor",
     "corequantity": 2,
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9026"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9026",
+    "categories": "Resource Acceleration"
   },
   {
-    "name": "Celebrían's Stone",
+    "name": "Celebr\u00edan's Stone",
     "type": "3attachment",
     "sphere": "1leadership",
     "cost": 2,
@@ -846,11 +854,11 @@
     "traits": " Artifact. Item.",
     "keywords": "Restricted.",
     "text": "Attach to a hero.\nAttached hero gains +2 Willpower.\nIf attached hero is Aragorn, he also gains a Spirit resource icon.",
-    "flavor": null,
     "textc": "Restricted.\nAttach to a hero.\nAttached hero gains +2 Willpower.\nIf attached hero is Aragorn, he also gains a Spirit resource icon.",
     "name_norm": "Celebrian's Stone",
     "corequantity": 1,
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9027"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9027",
+    "categories": "Resource Smoothing"
   },
   {
     "name": "Blade Mastery",
@@ -865,11 +873,11 @@
     "traits": "",
     "keywords": "",
     "text": "Action: Choose a character. Until the end of the phase, that character gains +1 Attack and +1 Defense.",
-    "flavor": null,
     "textc": "Action: Choose a character. Until the end of the phase, that character gains +1 Attack and +1 Defense.",
     "name_norm": "Blade Mastery",
     "corequantity": 3,
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9032"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9032",
+    "categories": "Attack Bonus, Defense Bonus"
   },
   {
     "name": "Rain of Arrows",
@@ -888,7 +896,8 @@
     "textc": "Action: Exhaust a character you control with the ranged keyword to choose a player. Deal 1 damage to each enemy engaged with that player.",
     "name_norm": "Rain of Arrows",
     "corequantity": 2,
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9033"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9033",
+    "categories": "Direct Damage"
   },
   {
     "name": "Feint",
@@ -903,11 +912,11 @@
     "traits": "",
     "keywords": "",
     "text": "Combat Action: Choose an enemy engaged with a player. That enemy cannot attack that player this phase.",
-    "flavor": null,
     "textc": "Combat Action: Choose an enemy engaged with a player. That enemy cannot attack that player this phase.",
     "name_norm": "Feint",
     "corequantity": 2,
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9034"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9034",
+    "categories": "Combat Control"
   },
   {
     "name": "Quick Strike",
@@ -926,7 +935,8 @@
     "textc": "Action: Exhaust a character you control to immediately declare it as an attacker (and resolve its attack) against any eligible enemy target.",
     "name_norm": "Quick Strike",
     "corequantity": 2,
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9035"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9035",
+    "categories": ""
   },
   {
     "name": "Thicket of Spears",
@@ -941,11 +951,11 @@
     "traits": "",
     "keywords": "",
     "text": "You must use resources from 3 different heroes' pools to pay for this card.\n                \nAction: Choose a player. That player's engaged enemies cannot attack that player this phase.",
-    "flavor": null,
     "textc": "You must use resources from 3 different heroes' pools to pay for this card.\n                \nAction: Choose a player. That player's engaged enemies cannot attack that player this phase.",
     "name_norm": "Thicket of Spears",
     "corequantity": 2,
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9036"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9036",
+    "categories": "Combat Control"
   },
   {
     "name": "Swift Strike",
@@ -960,11 +970,11 @@
     "traits": "",
     "keywords": "",
     "text": "Response: After a character is declared as a defender, deal 2 damage to the attacking enemy.",
-    "flavor": null,
     "textc": "Response: After a character is declared as a defender, deal 2 damage to the attacking enemy.",
     "name_norm": "Swift Strike",
     "corequantity": 1,
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9037"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9037",
+    "categories": "Direct Damage"
   },
   {
     "name": "Stand Together",
@@ -983,7 +993,8 @@
     "textc": "Action: Choose a player. That player may declare any number of his eligible characters as defenders against each enemy attacking him this phase.",
     "name_norm": "Stand Together",
     "corequantity": 1,
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9038"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9038",
+    "categories": ""
   },
   {
     "name": "Blade of Gondolin",
@@ -998,11 +1009,11 @@
     "traits": " Item. Weapon.",
     "keywords": "Restricted.",
     "text": "Attach to a hero.\nAttached hero gets +1 Attack when attacking an Orc.\nResponse: After attached hero attacks and destroys an enemy, place 1 progress token on the current quest.",
-    "flavor": null,
     "textc": "Restricted.\nAttach to a hero.\nAttached hero gets +1 Attack when attacking an Orc.\nResponse: After attached hero attacks and destroys an enemy, place 1 progress token on the current quest.",
     "name_norm": "Blade of Gondolin",
     "corequantity": 2,
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9039"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9039",
+    "categories": "Attack Bonus"
   },
   {
     "name": "Citadel Plate",
@@ -1017,11 +1028,11 @@
     "traits": " Item. Armor.",
     "keywords": "Restricted.",
     "text": "Attach to a hero.\nAttached hero gets +4 Hit Points.",
-    "flavor": null,
     "textc": "Restricted.\nAttach to a hero.\nAttached hero gets +4 Hit Points.",
     "name_norm": "Citadel Plate",
     "corequantity": 2,
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9040"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9040",
+    "categories": "Hit Point Bonus"
   },
   {
     "name": "Dwarven Axe",
@@ -1036,11 +1047,11 @@
     "traits": " Item. Weapon.",
     "keywords": "Restricted.",
     "text": "Attach to a hero.\nAttached hero gains +1 Attack. (+2 Attack instead if attached hero is a Dwarf.)",
-    "flavor": null,
     "textc": "Restricted.\nAttach to a hero.\nAttached hero gains +1 Attack. (+2 Attack instead if attached hero is a Dwarf.)",
     "name_norm": "Dwarven Axe",
     "corequantity": 2,
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9041"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9041",
+    "categories": "Attack Bonus"
   },
   {
     "name": "Horn of Gondor",
@@ -1055,11 +1066,11 @@
     "traits": " Item. Artifact.",
     "keywords": "Restricted.",
     "text": "Attach to a hero.\nResponse: After a character is destroyed, add 1 resource to attached hero's pool.",
-    "flavor": null,
     "textc": "Restricted.\nAttach to a hero.\nResponse: After a character is destroyed, add 1 resource to attached hero's pool.",
     "name_norm": "Horn of Gondor",
     "corequantity": 1,
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9042"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9042",
+    "categories": "Resource Acceleration"
   },
   {
     "name": "The Galadhrim's Greeting",
@@ -1074,11 +1085,12 @@
     "traits": "",
     "keywords": "",
     "text": "Action: Reduce one player's threat by 6, or reduce each player's threat by 2.",
-    "flavor": "`Welcome to Caras Galadhan!` he said. `Here is the city of the Galadhrim where dwell the Lord Celeborn and Galadriel the Lady of Lórien` -The Fellowship of the Ring",
+    "flavor": "`Welcome to Caras Galadhan!` he said. `Here is the city of the Galadhrim where dwell the Lord Celeborn and Galadriel the Lady of L\u00f3rien` -The Fellowship of the Ring",
     "textc": "Action: Reduce one player's threat by 6, or reduce each player's threat by 2.",
     "name_norm": "The Galadhrim's Greeting",
     "corequantity": 2,
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9046"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9046",
+    "categories": "Threat Control"
   },
   {
     "name": "Strength of Will",
@@ -1093,11 +1105,11 @@
     "traits": "",
     "keywords": "",
     "text": "Response: After you travel to a location, exhaust a Spirit character to place 2 progress tokens on that location.",
-    "flavor": null,
     "textc": "Response: After you travel to a location, exhaust a Spirit character to place 2 progress tokens on that location.",
     "name_norm": "Strength of Will",
     "corequantity": 2,
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9047"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9047",
+    "categories": ""
   },
   {
     "name": "Hasty Stroke",
@@ -1112,11 +1124,11 @@
     "traits": "",
     "keywords": "",
     "text": "Response: Cancel a shadow effect just triggered during combat.",
-    "flavor": null,
     "textc": "Response: Cancel a shadow effect just triggered during combat.",
     "name_norm": "Hasty Stroke",
     "corequantity": 2,
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9048"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9048",
+    "categories": "Shadow Control"
   },
   {
     "name": "Will of the West",
@@ -1135,7 +1147,8 @@
     "textc": "Action: Choose a player. Shuffle that player's discard pile back into his deck.",
     "name_norm": "Will of the West",
     "corequantity": 2,
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9049"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9049",
+    "categories": ""
   },
   {
     "name": "A Test of Will",
@@ -1150,17 +1163,17 @@
     "traits": "",
     "keywords": "",
     "text": "Response: Cancel the 'when revealed' effects of a card that was just revealed from the encounter deck.",
-    "flavor": null,
     "textc": "Response: Cancel the 'when revealed' effects of a card that was just revealed from the encounter deck.",
     "name_norm": "A Test of Will",
     "corequantity": 2,
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9050"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9050",
+    "categories": ""
   },
   {
     "name": "Stand and Fight",
     "type": "4event",
     "sphere": "3spirit",
-    "cost": "X",
+    "cost": 0,
     "cycle": 0,
     "exp": "core",
     "no": 51,
@@ -1173,7 +1186,8 @@
     "textc": "Action: Choose an ally with a printed cost of X in any player's discard pile. Put that ally into play under your control. (The chosen ally can belong to any sphere of influence.)",
     "name_norm": "Stand and Fight",
     "corequantity": 3,
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9051"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9051",
+    "categories": ""
   },
   {
     "name": "A Light in the Dark",
@@ -1188,11 +1202,11 @@
     "traits": "",
     "keywords": "",
     "text": "Action: Choose an enemy engaged with a player. Return that enemy to the staging area.",
-    "flavor": null,
     "textc": "Action: Choose an enemy engaged with a player. Return that enemy to the staging area.",
     "name_norm": "A Light in the Dark",
     "corequantity": 2,
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9052"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9052",
+    "categories": ""
   },
   {
     "name": "Dwarven Tomb",
@@ -1207,11 +1221,11 @@
     "traits": "",
     "keywords": "",
     "text": "Action: Return 1 Spirit card from your discard pile to your hand.",
-    "flavor": null,
     "textc": "Action: Return 1 Spirit card from your discard pile to your hand.",
     "name_norm": "Dwarven Tomb",
     "corequantity": 1,
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9053"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9053",
+    "categories": ""
   },
   {
     "name": "Fortune or Fate",
@@ -1226,11 +1240,11 @@
     "traits": "",
     "keywords": "",
     "text": "Action: Choose a hero in any player's discard pile. Put that card into play, under its owner's control.",
-    "flavor": null,
     "textc": "Action: Choose a hero in any player's discard pile. Put that card into play, under its owner's control.",
     "name_norm": "Fortune or Fate",
     "corequantity": 1,
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9054"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9054",
+    "categories": ""
   },
   {
     "name": "The Favor of the Lady",
@@ -1245,11 +1259,11 @@
     "traits": " Condition.",
     "keywords": "",
     "text": "Attach to a hero.\nAttached hero gains +1 Willpower.",
-    "flavor": null,
     "textc": "Attach to a hero.\nAttached hero gains +1 Willpower.",
     "name_norm": "The Favor of the Lady",
     "corequantity": 2,
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9055"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9055",
+    "categories": ""
   },
   {
     "name": "Power in the Earth",
@@ -1264,11 +1278,11 @@
     "traits": " Condition.",
     "keywords": "",
     "text": "Attach to a location.\nAttached location gets -1 Threat.",
-    "flavor": null,
     "textc": "Attach to a location.\nAttached location gets -1 Threat.",
     "name_norm": "Power in the Earth",
     "corequantity": 2,
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9056"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9056",
+    "categories": ""
   },
   {
     "name": "Unexpected Courage",
@@ -1283,11 +1297,11 @@
     "traits": " Condition.",
     "keywords": "",
     "text": "Attach to a hero.\nAction: Exhaust Unexpected Courage to ready attached hero.",
-    "flavor": null,
     "textc": "Attach to a hero.\nAction: Exhaust Unexpected Courage to ready attached hero.",
     "name_norm": "Unexpected Courage",
     "corequantity": 1,
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9057"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9057",
+    "categories": "Readying"
   },
   {
     "name": "Lore of Imladris",
@@ -1302,14 +1316,14 @@
     "traits": "",
     "keywords": "",
     "text": "Action: Choose a character. Heal all damage from that character.",
-    "flavor": null,
     "textc": "Action: Choose a character. Heal all damage from that character.",
     "name_norm": "Lore of Imladris",
     "corequantity": 3,
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9063"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9063",
+    "categories": "Healing"
   },
   {
-    "name": "Lórien's Wealth",
+    "name": "L\u00f3rien's Wealth",
     "type": "4event",
     "sphere": "4lore",
     "cost": 3,
@@ -1321,11 +1335,11 @@
     "traits": "",
     "keywords": "",
     "text": "Action: Choose a player. That player draws 3 cards.",
-    "flavor": null,
     "textc": "Action: Choose a player. That player draws 3 cards.",
     "name_norm": "Lorien's Wealth",
     "corequantity": 2,
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9064"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9064",
+    "categories": "Card Draw"
   },
   {
     "name": "Radagast's Cunning",
@@ -1344,7 +1358,8 @@
     "textc": "Quest Action: Choose an enemy in the staging area. Until the end of the phase, that enemy does not contribute its Threat.",
     "name_norm": "Radagast's Cunning",
     "corequantity": 2,
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9065"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9065",
+    "categories": ""
   },
   {
     "name": "Secret Paths",
@@ -1363,13 +1378,14 @@
     "textc": "Quest Action: Choose a location in the staging area. Until the end of the phase, that location does not contribute its Threat.",
     "name_norm": "Secret Paths",
     "corequantity": 2,
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9066"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9066",
+    "categories": ""
   },
   {
     "name": "Gandalf's Search",
     "type": "4event",
     "sphere": "4lore",
-    "cost": "X",
+    "cost": 0,
     "cycle": 0,
     "exp": "core",
     "no": 67,
@@ -1378,11 +1394,11 @@
     "traits": "",
     "keywords": "",
     "text": "Action: Look at the top X cards of any player's deck, add 1 of those cards to its owner's hand, and return the rest to the top of the deck in any order.",
-    "flavor": null,
     "textc": "Action: Look at the top X cards of any player's deck, add 1 of those cards to its owner's hand, and return the rest to the top of the deck in any order.",
     "name_norm": "Gandalf's Search",
     "corequantity": 2,
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9067"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9067",
+    "categories": ""
   },
   {
     "name": "Beorn's Hospitality",
@@ -1397,11 +1413,11 @@
     "traits": "",
     "keywords": "",
     "text": "Action: Choose a player. Heal all damage on each hero controlled by that player.",
-    "flavor": null,
     "textc": "Action: Choose a player. Heal all damage on each hero controlled by that player.",
     "name_norm": "Beorn's Hospitality",
     "corequantity": 1,
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9068"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9068",
+    "categories": "Healing"
   },
   {
     "name": "Forest Snare",
@@ -1416,14 +1432,14 @@
     "traits": " Item. Trap.",
     "keywords": "",
     "text": "Attach to an enemy engaged with a player.\nAttached enemy cannot attack.",
-    "flavor": null,
     "textc": "Attach to an enemy engaged with a player.\nAttached enemy cannot attack.",
     "name_norm": "Forest Snare",
     "corequantity": 2,
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9069"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9069",
+    "categories": "Combat Control"
   },
   {
-    "name": "Protector of Lórien",
+    "name": "Protector of L\u00f3rien",
     "type": "3attachment",
     "sphere": "4lore",
     "cost": 1,
@@ -1435,11 +1451,11 @@
     "traits": " Title.",
     "keywords": "",
     "text": "Attach to a hero.\nAction: Discard a card from your hand to give attached hero +1 Defense or +1 Willpower until the end of the phase. Limit 3 times per phase.",
-    "flavor": null,
     "textc": "Attach to a hero.\nAction: Discard a card from your hand to give attached hero +1 Defense or +1 Willpower until the end of the phase. Limit 3 times per phase.",
     "name_norm": "Protector of Lorien",
     "corequantity": 2,
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9070"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9070",
+    "categories": "Defense Bonus"
   },
   {
     "name": "Dark Knowledge",
@@ -1454,11 +1470,11 @@
     "traits": " Condition.",
     "keywords": "",
     "text": "Attach to a hero. Attached hero gets -1 Willpower.\nResponse: Exhaust Dark Knowledge to look at 1 shadow card that was just dealt to an enemy attacking you.",
-    "flavor": null,
     "textc": "Attach to a hero. Attached hero gets -1 Willpower.\nResponse: Exhaust Dark Knowledge to look at 1 shadow card that was just dealt to an enemy attacking you.",
     "name_norm": "Dark Knowledge",
     "corequantity": 1,
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9071"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9071",
+    "categories": "Shadow Control"
   },
   {
     "name": "Self Preservation",
@@ -1473,11 +1489,11 @@
     "traits": " Skill.",
     "keywords": "",
     "text": "Attach to a character.\nAction: Exhaust Self Preservation to heal 2 points of damage from attached character.",
-    "flavor": null,
     "textc": "Attach to a character.\nAction: Exhaust Self Preservation to heal 2 points of damage from attached character.",
     "name_norm": "Self Preservation",
     "corequantity": 2,
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9072"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9072",
+    "categories": "Healing"
   },
   {
     "name": "Gandalf",
@@ -1496,11 +1512,11 @@
     "traits": " Istari.",
     "keywords": "",
     "text": "At the end of the round, discard Gandalf from play.\nResponse: After Gandalf enters play, (choose 1): draw 3 cards, deal 4 damage to 1 enemy in play, or reduce your threat by 5.",
-    "flavor": null,
     "textc": "At the end of the round, discard Gandalf from play.\nResponse: After Gandalf enters play, (choose 1): draw 3 cards, deal 4 damage to 1 enemy in play, or reduce your threat by 5.",
     "name_norm": "Gandalf",
     "corequantity": 4,
-    "octgn": "51223bd0-ffd1-11df-a976-0801200c9073"
+    "octgn": "51223bd0-ffd1-11df-a976-0801200c9073",
+    "categories": "Card Draw, Direct Damage, Threat Control"
   },
   {
     "name": "Bilbo Baggins",
@@ -1522,10 +1538,11 @@
     "flavor": "`Well, my dear fellow,` said bilbo, `now you've heard the news, can't you spare me a moment? I want your help in something urgent.` -The Fellowship of the Ring",
     "textc": "The first player draws 1 additional card in the resource phase.",
     "name_norm": "Bilbo Baggins",
-    "octgn": "51223bd0-ffd1-11df-a976-0801201c9001"
+    "octgn": "51223bd0-ffd1-11df-a976-0801201c9001",
+    "categories": "Card Draw"
   },
   {
-    "name": "Dúnedain Mark",
+    "name": "D\u00fanedain Mark",
     "type": "3attachment",
     "sphere": "1leadership",
     "cost": 1,
@@ -1537,10 +1554,10 @@
     "traits": " Signal.",
     "keywords": "",
     "text": "Attach to a hero.\nAttached hero gains +1 Attack.\nAction: Pay 1 resource from attached hero's pool to attach Dunedain Mark to another hero.",
-    "flavor": null,
     "textc": "Attach to a hero.\nAttached hero gains +1 Attack.\nAction: Pay 1 resource from attached hero's pool to attach Dunedain Mark to another hero.",
     "name_norm": "Dunedain Mark",
-    "octgn": "51223bd0-ffd1-11df-a976-0801201c9002"
+    "octgn": "51223bd0-ffd1-11df-a976-0801201c9002",
+    "categories": "Attack Bonus"
   },
   {
     "name": "Campfire Tales",
@@ -1558,7 +1575,8 @@
     "flavor": "`It is a fair tale, though it is sad, as are all the tales of Middle-earth, and yet it may lift up your hearts.` -Strider, The Fellowship of the Ring",
     "textc": "Action: Each player draws 1 card.",
     "name_norm": "Campfire Tales",
-    "octgn": "51223bd0-ffd1-11df-a976-0801201c9003"
+    "octgn": "51223bd0-ffd1-11df-a976-0801201c9003",
+    "categories": "Card Draw"
   },
   {
     "name": "Winged Guardian",
@@ -1577,10 +1595,10 @@
     "traits": " Creature. Eagle.",
     "keywords": "Sentinel.",
     "text": "Winged Guardian cannot have restricted attachments.\nForced: After an attack in which Winged Guardian defends resolves, pay 1 Tactics resource or discard Winged Guardian from play.",
-    "flavor": null,
     "textc": "Sentinel.\nWinged Guardian cannot have restricted attachments.\nForced: After an attack in which Winged Guardian defends resolves, pay 1 Tactics resource or discard Winged Guardian from play.",
     "name_norm": "Winged Guardian",
-    "octgn": "51223bd0-ffd1-11df-a976-0801201c9010"
+    "octgn": "51223bd0-ffd1-11df-a976-0801201c9010",
+    "categories": ""
   },
   {
     "name": "The Eagles Are Coming!",
@@ -1598,7 +1616,8 @@
     "flavor": "`The Eagles! The Eagles!` -Bilbo Baggins, The Hobbit",
     "textc": "Action: Search the top 5 cards of your deck for any number of Eagle cards and add them to your hand. Shuffle the other cards back into your deck.",
     "name_norm": "The Eagles Are Coming",
-    "octgn": "51223bd0-ffd1-11df-a976-0801201c9008"
+    "octgn": "51223bd0-ffd1-11df-a976-0801201c9008",
+    "categories": "Card Search"
   },
   {
     "name": "Westfold Horse-Breaker",
@@ -1620,7 +1639,8 @@
     "flavor": "`Your own valour has done more, and the stout legs of the Westfold-men marching through the night.` -Gandalf, The Two Towers",
     "textc": "Action: Discard Westfold Horse-Breaker to choose and ready a hero.",
     "name_norm": "Westfold Horse-Breaker",
-    "octgn": "51223bd0-ffd1-11df-a976-0801201c9009"
+    "octgn": "51223bd0-ffd1-11df-a976-0801201c9009",
+    "categories": "Readying"
   },
   {
     "name": "Mustering the Rohirrim",
@@ -1635,10 +1655,11 @@
     "traits": "",
     "keywords": "",
     "text": "Action: Search the top 10 cards of your deck for any 1 Rohan ally card and add it to your hand. Then, shuffle the other cards back into your deck.",
-    "flavor": "`More speed we cannot make, if the strength of Rohan is to be gathered.` -Éomer, The Return of the King",
+    "flavor": "`More speed we cannot make, if the strength of Rohan is to be gathered.` -\u00c9omer, The Return of the King",
     "textc": "Action: Search the top 10 cards of your deck for any 1 Rohan ally card and add it to your hand. Then, shuffle the other cards back into your deck.",
     "name_norm": "Mustering the Rohirrim",
-    "octgn": "51223bd0-ffd1-11df-a976-0801201c9004"
+    "octgn": "51223bd0-ffd1-11df-a976-0801201c9004",
+    "categories": "Card Search"
   },
   {
     "name": "Rivendell Minstrel",
@@ -1660,7 +1681,8 @@
     "flavor": "As Elrond entered and went towards the seat prepared for him, Elvish minstrels began to make sweet music. -The Fellowship of the Ring",
     "textc": "Response: After you play Rivendell Minstrel from your hand, search your deck for 1 Song card and add it to your hand. Shuffle your deck.",
     "name_norm": "Rivendell Minstrel",
-    "octgn": "51223bd0-ffd1-11df-a976-0801201c9005"
+    "octgn": "51223bd0-ffd1-11df-a976-0801201c9005",
+    "categories": "Card Search"
   },
   {
     "name": "Strider's Path",
@@ -1678,7 +1700,8 @@
     "flavor": "`My cuts, short or long, don't go wrong.` -Strider, The Fellowship of the Ring",
     "textc": "Response: After a location is revealed from the encounter deck, immediately travel to that location without resolving its Travel effect. If another location is currently active, return it to the staging area.",
     "name_norm": "Strider's Path",
-    "octgn": "51223bd0-ffd1-11df-a976-0801201c9007"
+    "octgn": "51223bd0-ffd1-11df-a976-0801201c9007",
+    "categories": ""
   },
   {
     "name": "Song of Kings",
@@ -1696,7 +1719,8 @@
     "flavor": "From the ashes a fire shall be woken,\nA light from the shadows shall spring: \nRenewed shall be blade that was broken,\nThe crownless again shall be king.\n-The Fellowship of the Ring",
     "textc": "Attach to a hero.\nAttached hero gains a Leadership resource icon.",
     "name_norm": "Song of Kings",
-    "octgn": "51223bd0-ffd1-11df-a976-0801201c9006"
+    "octgn": "51223bd0-ffd1-11df-a976-0801201c9006",
+    "categories": "Resource Smoothing"
   },
   {
     "name": "Frodo Baggins",
@@ -1718,10 +1742,11 @@
     "flavor": "Frodo began to feel restless, and the old paths seemed too well-trodden. he looked at maps and wondered what lay beyond their edges... -The Fellowship of the Ring",
     "textc": "Response: After Frodo Baggins is damaged, cancel the damage and instead raise your threat by the amount of damage he would have been dealt. (Limit once per phase.)",
     "name_norm": "Frodo Baggins",
-    "octgn": "51223bd0-ffd1-11df-a976-0801202c9001"
+    "octgn": "51223bd0-ffd1-11df-a976-0801202c9001",
+    "categories": ""
   },
   {
-    "name": "Dúnedain Warning",
+    "name": "D\u00fanedain Warning",
     "type": "3attachment",
     "sphere": "1leadership",
     "cost": 1,
@@ -1733,10 +1758,10 @@
     "traits": " Signal.",
     "keywords": "",
     "text": "Attach to a hero.\nAttached hero gains +1 Defense.\nAction: Pay 1 resource from attached hero's pool to attach Dunedain Warning to another hero.",
-    "flavor": null,
     "textc": "Attach to a hero.\nAttached hero gains +1 Defense.\nAction: Pay 1 resource from attached hero's pool to attach Dunedain Warning to another hero.",
     "name_norm": "Dunedain Warning",
-    "octgn": "51223bd0-ffd1-11df-a976-0801202c9008"
+    "octgn": "51223bd0-ffd1-11df-a976-0801202c9008",
+    "categories": "Defense Bonus"
   },
   {
     "name": "Second Breakfast",
@@ -1751,10 +1776,10 @@
     "traits": "",
     "keywords": "",
     "text": "Action: Each player returns the topmost attachment card from his discard pile to his hand.",
-    "flavor": null,
     "textc": "Action: Each player returns the topmost attachment card from his discard pile to his hand.",
     "name_norm": "Second Breakfast",
-    "octgn": "51223bd0-ffd1-11df-a976-0801202c9024"
+    "octgn": "51223bd0-ffd1-11df-a976-0801202c9024",
+    "categories": ""
   },
   {
     "name": "Beorning Beekeeper",
@@ -1776,7 +1801,8 @@
     "flavor": "`We are getting near,` said Gandalf. `We are on th eedge of his bee pastures.` - The Hobbit",
     "textc": "Action: Discard Beorning Beekeeper from play to deal 1 damage to each enemy in the staging area.",
     "name_norm": "Beorning Beekeeper",
-    "octgn": "51223bd0-ffd1-11df-a976-0801202c9006"
+    "octgn": "51223bd0-ffd1-11df-a976-0801202c9006",
+    "categories": "Direct Damage"
   },
   {
     "name": "Born Aloft",
@@ -1794,10 +1820,11 @@
     "flavor": "`Very well,` said Gandalf. `Take us where and as far as you will!` -The Hobbit",
     "textc": "Attach to an ally.\nAction: Discard Born Aloft from play to return attached ally to its owner's hand.",
     "name_norm": "Born Aloft",
-    "octgn": "51223bd0-ffd1-11df-a976-0801202c9007"
+    "octgn": "51223bd0-ffd1-11df-a976-0801202c9007",
+    "categories": ""
   },
   {
-    "name": "Éomund",
+    "name": "\u00c9omund",
     "type": "2ally",
     "sphere": "3spirit",
     "cost": 3,
@@ -1812,11 +1839,12 @@
     "unique": true,
     "traits": " Rohan.",
     "keywords": "",
-    "text": "Response: After Éomund leaves play, ready all Rohan characters in play.",
+    "text": "Response: After \u00c9omund leaves play, ready all Rohan characters in play.",
     "flavor": "`You I have not seen before, for you are young, but I have spoken with Eomund your father...` -Aragorn, The Two Towers",
-    "textc": "Response: After Éomund leaves play, ready all Rohan characters in play.",
+    "textc": "Response: After \u00c9omund leaves play, ready all Rohan characters in play.",
     "name_norm": "Eomund",
-    "octgn": "51223bd0-ffd1-11df-a976-0801202c9009"
+    "octgn": "51223bd0-ffd1-11df-a976-0801202c9009",
+    "categories": "Readying"
   },
   {
     "name": "Nor am I a Stranger",
@@ -1834,7 +1862,8 @@
     "flavor": "`Nor indeed am I a stranger: for I have been in this land before, more than once, and ridden with the host of the Rohirrim, though under other name and in other guise.` -Aragorn, The Two Towers",
     "textc": "Attach to a character.\nAttached character gains the Rohan trait.",
     "name_norm": "Nor am I a Stranger",
-    "octgn": "51223bd0-ffd1-11df-a976-0801202c9018"
+    "octgn": "51223bd0-ffd1-11df-a976-0801202c9018",
+    "categories": ""
   },
   {
     "name": "Longbeard Map-Maker",
@@ -1856,7 +1885,8 @@
     "flavor": "On the table in the light of a big lamp with a red shade he spread a piece of parchment rather like a map. -The Hobbit",
     "textc": "Action: Spend 1 Lore resource to give Longbeard Map-Maker +1 Willpower until the end of the phase.",
     "name_norm": "Longbeard Map-Maker",
-    "octgn": "51223bd0-ffd1-11df-a976-0801202c9014"
+    "octgn": "51223bd0-ffd1-11df-a976-0801202c9014",
+    "categories": ""
   },
   {
     "name": "A Burning Brand",
@@ -1874,7 +1904,8 @@
     "flavor": "`Keep close to the fire, with your faces outward!` cried Strider. `Keep some of th elonger sticks ready in your hands.` -The Fellowship of the Ring",
     "textc": "Attach to a Lore character.\nWhile attached character is defending, cancel any shadow effects on cards dealt to the attacking enemy.",
     "name_norm": "A Burning Brand",
-    "octgn": "51223bd0-ffd1-11df-a976-0801202c9010"
+    "octgn": "51223bd0-ffd1-11df-a976-0801202c9010",
+    "categories": "Shadow Control"
   },
   {
     "name": "Song of Wisdom",
@@ -1889,10 +1920,10 @@
     "traits": " Song.",
     "keywords": "",
     "text": "Attach to a hero.\nAttached hero gains a Lore resource icon.",
-    "flavor": null,
     "textc": "Attach to a hero.\nAttached hero gains a Lore resource icon.",
     "name_norm": "Song of Wisdom",
-    "octgn": "51223bd0-ffd1-11df-a976-0801202c9025"
+    "octgn": "51223bd0-ffd1-11df-a976-0801202c9025",
+    "categories": "Resource Smoothing"
   },
   {
     "name": "Prince Imrahil",
@@ -1914,10 +1945,11 @@
     "flavor": "But beyond, in the great fief of Belfalas, dwelt Prince Imrahil in his castle of Dol Amroth by the sea, and he was of high blood, and his fold also, tall men and proud with sea-grey eyes. -The Return of the King.",
     "textc": "Response: After a character leaves play, ready Prince Imrahil. (Limit once per round.)",
     "name_norm": "Prince Imrahil",
-    "octgn": "51223bd0-ffd1-11df-a976-0801203c9001"
+    "octgn": "51223bd0-ffd1-11df-a976-0801203c9001",
+    "categories": "Readying"
   },
   {
-    "name": "Dúnedain Quest",
+    "name": "D\u00fanedain Quest",
     "type": "3attachment",
     "sphere": "1leadership",
     "cost": 2,
@@ -1929,10 +1961,10 @@
     "traits": " Signal.",
     "keywords": "",
     "text": "Attach to a hero.\nAttached hero gains +1 Willpower.\nAction: Pay 1 resource from attached hero's pool to attach Dunedain Quest to another hero.",
-    "flavor": null,
     "textc": "Attach to a hero.\nAttached hero gains +1 Willpower.\nAction: Pay 1 resource from attached hero's pool to attach Dunedain Quest to another hero.",
     "name_norm": "Dunedain Quest",
-    "octgn": "51223bd0-ffd1-11df-a976-0801203c9008"
+    "octgn": "51223bd0-ffd1-11df-a976-0801203c9008",
+    "categories": ""
   },
   {
     "name": "Parting Gifts",
@@ -1950,7 +1982,8 @@
     "flavor": "Inside the hall there was piled a large assortment of packages and parcels and small articles of furniture. -The Fellowship of the Ring",
     "textc": "Action: Move any number of resource tokens from a Leadership hero's resource pool to any other hero's resource pool.",
     "name_norm": "Parting Gifts",
-    "octgn": "51223bd0-ffd1-11df-a976-0801203c9007"
+    "octgn": "51223bd0-ffd1-11df-a976-0801203c9007",
+    "categories": "Resource Smoothing"
   },
   {
     "name": "Landroval",
@@ -1969,10 +2002,10 @@
     "traits": " Creature. Eagle.",
     "keywords": "Sentinel.",
     "text": "Landroval cannot have restricted attachments.\nResponse: After a hero card is destroyed, return Landroval to his owner's hand to put that hero back into play, with 1 damage token on it. (Limit once per game.)",
-    "flavor": null,
     "textc": "Sentinel.\nLandroval cannot have restricted attachments.\nResponse: After a hero card is destroyed, return Landroval to his owner's hand to put that hero back into play, with 1 damage token on it. (Limit once per game.)",
     "name_norm": "Landroval",
-    "octgn": "51223bd0-ffd1-11df-a976-0801203c9004"
+    "octgn": "51223bd0-ffd1-11df-a976-0801203c9004",
+    "categories": ""
   },
   {
     "name": "To the Eyrie",
@@ -1990,7 +2023,8 @@
     "flavor": "The pale peaks of the mountains were coming nearer, moonlit spikes of rock sticking out of black shadows. -The Hobbit",
     "textc": "Response: After an ally is destroyed, exhaust 1 Eagle character to move that ally from the discard pile to its owner's hand.",
     "name_norm": "To the Eyrie",
-    "octgn": "51223bd0-ffd1-11df-a976-0801203c9010"
+    "octgn": "51223bd0-ffd1-11df-a976-0801203c9010",
+    "categories": ""
   },
   {
     "name": "Escort from Edoras",
@@ -2009,10 +2043,10 @@
     "traits": " Rohan.",
     "keywords": "",
     "text": "While committed to a quest, Escort from Edoras gets +2 Willpower.\nForced: After resolving a quest to which Escort from Edoras was committed, discard Escort from Edoras from play.",
-    "flavor": null,
     "textc": "While committed to a quest, Escort from Edoras gets +2 Willpower.\nForced: After resolving a quest to which Escort from Edoras was committed, discard Escort from Edoras from play.",
     "name_norm": "Escort from Edoras",
-    "octgn": "51223bd0-ffd1-11df-a976-0801203c9009"
+    "octgn": "51223bd0-ffd1-11df-a976-0801203c9009",
+    "categories": ""
   },
   {
     "name": "Ancient Mathom",
@@ -2030,10 +2064,11 @@
     "flavor": "The Mathom-house it was called; for anything that Hobbits had no immediate use for, but were unwilling to throw away, they called a mathom. Their dwellings were apt to become rather crowded with mathoms... -The Fellowship of the Ring",
     "textc": "Attach to a location.\nResponse: After attached location is explored, the first player draws 3 cards.",
     "name_norm": "Ancient Mathom",
-    "octgn": "51223bd0-ffd1-11df-a976-0801203c9005"
+    "octgn": "51223bd0-ffd1-11df-a976-0801203c9005",
+    "categories": "Card Draw"
   },
   {
-    "name": "Haldir of Lórien",
+    "name": "Haldir of L\u00f3rien",
     "type": "2ally",
     "sphere": "4lore",
     "cost": 4,
@@ -2052,7 +2087,8 @@
     "flavor": "`But there are some of us still who go abroad for the gathering of news and the watching of our enemies, and they speak the languages of other lands.` -The Fellowship of the Ring",
     "textc": "Ranged.. Sentinel.\n",
     "name_norm": "Haldir of Lorien",
-    "octgn": "51223bd0-ffd1-11df-a976-0801203c9002"
+    "octgn": "51223bd0-ffd1-11df-a976-0801203c9002",
+    "categories": ""
   },
   {
     "name": "Infighting",
@@ -2070,7 +2106,8 @@
     "flavor": "That's cursed rebel-talk, and I'll stick you, if you don't shut it down, see? -Orc Soldier, The Return of the King",
     "textc": "Action: Move any number of damage from one enemy to another.",
     "name_norm": "Infighting",
-    "octgn": "51223bd0-ffd1-11df-a976-0801203c9006"
+    "octgn": "51223bd0-ffd1-11df-a976-0801203c9006",
+    "categories": ""
   },
   {
     "name": "Radagast",
@@ -2092,7 +2129,8 @@
     "flavor": "`I have an urgent errand. My news is evil.`",
     "textc": "Radagast collects 1 resource each resource phase. These resources can be used to pay for Creature cards played from your hand.\nAction: Spend X resources from Radagast's pool to heal X wounds on any 1 Creature.",
     "name_norm": "Radagast",
-    "octgn": "51223bd0-ffd1-11df-a976-0801203c9003"
+    "octgn": "51223bd0-ffd1-11df-a976-0801203c9003",
+    "categories": ""
   },
   {
     "name": "Brand son of Bain",
@@ -2111,10 +2149,10 @@
     "traits": " Dale.",
     "keywords": "Ranged.",
     "text": "Response: After Brand son of Bain attacks and defeats an enemy engaged with another player, choose and ready one of that player's characters.",
-    "flavor": null,
     "textc": "Ranged.\nResponse: After Brand son of Bain attacks and defeats an enemy engaged with another player, choose and ready one of that player's characters.",
     "name_norm": "Brand son of Bain",
-    "octgn": "51223bd0-ffd1-11df-a976-0801204c9003"
+    "octgn": "51223bd0-ffd1-11df-a976-0801204c9003",
+    "categories": "Readying"
   },
   {
     "name": "Keen-eyed Took",
@@ -2133,10 +2171,10 @@
     "traits": " Hobbit.",
     "keywords": "",
     "text": "Response: After Keen-eyed Took enters play, reveal the top card of each player's deck.\nAction: Return Keen-eyed Took to your hand to discard the top card of each player's deck.",
-    "flavor": null,
     "textc": "Response: After Keen-eyed Took enters play, reveal the top card of each player's deck.\nAction: Return Keen-eyed Took to your hand to discard the top card of each player's deck.",
     "name_norm": "Keen-eyed Took",
-    "octgn": "51223bd0-ffd1-11df-a976-0801204c9008"
+    "octgn": "51223bd0-ffd1-11df-a976-0801204c9008",
+    "categories": ""
   },
   {
     "name": "Rear Guard",
@@ -2151,10 +2189,10 @@
     "traits": "",
     "keywords": "",
     "text": "Quest Action: Discard a Leadership ally to give each hero committed to this quest +1 Willpower until the end of the phase.",
-    "flavor": null,
     "textc": "Quest Action: Discard a Leadership ally to give each hero committed to this quest +1 Willpower until the end of the phase.",
     "name_norm": "Rear Guard",
-    "octgn": "51223bd0-ffd1-11df-a976-0801204c9012"
+    "octgn": "51223bd0-ffd1-11df-a976-0801204c9012",
+    "categories": ""
   },
   {
     "name": "Descendant of Thorondor",
@@ -2173,10 +2211,10 @@
     "traits": " Creature. Eagle.",
     "keywords": "",
     "text": "Descendant of Thorondor cannot have restricted attachments.\nResponse: After Descendant of Thorondor enters or leaves play, deal 2 damage to any 1 enemy in the staging area.",
-    "flavor": null,
     "textc": "Descendant of Thorondor cannot have restricted attachments.\nResponse: After Descendant of Thorondor enters or leaves play, deal 2 damage to any 1 enemy in the staging area.",
     "name_norm": "Descendant of Thorondor",
-    "octgn": "51223bd0-ffd1-11df-a976-0801204c9004"
+    "octgn": "51223bd0-ffd1-11df-a976-0801204c9004",
+    "categories": "Direct Damage"
   },
   {
     "name": "Meneldor's Flight",
@@ -2191,10 +2229,10 @@
     "traits": "",
     "keywords": "",
     "text": "Action: Choose an Eagle ally. Return that character to its owner's hand.",
-    "flavor": null,
     "textc": "Action: Choose an Eagle ally. Return that character to its owner's hand.",
     "name_norm": "Meneldor's Flight",
-    "octgn": "51223bd0-ffd1-11df-a976-0801204c9009"
+    "octgn": "51223bd0-ffd1-11df-a976-0801204c9009",
+    "categories": ""
   },
   {
     "name": "The Riddermark's Finest",
@@ -2213,10 +2251,10 @@
     "traits": " Creature. Rohan.",
     "keywords": "",
     "text": "Action: Exhaust and discard The Riddermark's Finest to place 2 progress tokens on any location.",
-    "flavor": null,
     "textc": "Action: Exhaust and discard The Riddermark's Finest to place 2 progress tokens on any location.",
     "name_norm": "The Riddermark's Finest",
-    "octgn": "51223bd0-ffd1-11df-a976-0801204c9023"
+    "octgn": "51223bd0-ffd1-11df-a976-0801204c9023",
+    "categories": ""
   },
   {
     "name": "Ride to Ruin",
@@ -2231,10 +2269,10 @@
     "traits": "",
     "keywords": "",
     "text": "Action: Discard a Rohan ally to choose a location. Place 3 progress tokens on that location.",
-    "flavor": null,
     "textc": "Action: Discard a Rohan ally to choose a location. Place 3 progress tokens on that location.",
     "name_norm": "Ride to Ruin",
-    "octgn": "51223bd0-ffd1-11df-a976-0801204c9013"
+    "octgn": "51223bd0-ffd1-11df-a976-0801204c9013",
+    "categories": ""
   },
   {
     "name": "Gildor Inglorion",
@@ -2253,10 +2291,10 @@
     "traits": " Noldor.",
     "keywords": "",
     "text": "Action: Exhaust Gildor Inglorion to look at the top 3 cards of your deck. Switch one of those cards with a card from your hand. Then, return the 3 cards to the top of your deck, in any order.",
-    "flavor": null,
     "textc": "Action: Exhaust Gildor Inglorion to look at the top 3 cards of your deck. Switch one of those cards with a card from your hand. Then, return the 3 cards to the top of your deck, in any order.",
     "name_norm": "Gildor Inglorion",
-    "octgn": "51223bd0-ffd1-11df-a976-0801204c9005"
+    "octgn": "51223bd0-ffd1-11df-a976-0801204c9005",
+    "categories": ""
   },
   {
     "name": "Gildor's Counsel",
@@ -2271,10 +2309,10 @@
     "traits": "",
     "keywords": "",
     "text": "Play during the Quest phase, before characters are committed to the Quest.\nAction: Reveal 1 less card from the encounter deck this phase. (To a minimum of 1.)",
-    "flavor": null,
     "textc": "Play during the Quest phase, before characters are committed to the Quest.\nAction: Reveal 1 less card from the encounter deck this phase. (To a minimum of 1.)",
     "name_norm": "Gildor's Counsel",
-    "octgn": "51223bd0-ffd1-11df-a976-0801204c9006"
+    "octgn": "51223bd0-ffd1-11df-a976-0801204c9006",
+    "categories": ""
   },
   {
     "name": "Song of Travel",
@@ -2289,10 +2327,10 @@
     "traits": " Song.",
     "keywords": "",
     "text": "Attach to a hero.\nAttached hero gains a Spirit resource icon.",
-    "flavor": null,
     "textc": "Attach to a hero.\nAttached hero gains a Spirit resource icon.",
     "name_norm": "Song of Travel",
-    "octgn": "51223bd0-ffd1-11df-a976-0801204c9016"
+    "octgn": "51223bd0-ffd1-11df-a976-0801204c9016",
+    "categories": "Resource Smoothing"
   },
   {
     "name": "Boromir",
@@ -2314,10 +2352,11 @@
     "flavor": "`...in Gondor we must trust to such weapons as we have.` -The Fellowship of the Ring",
     "textc": "Action: Raise your threat by 1 to ready Boromir.\nAction: Discard Boromir to deal 2 damage to each enemy engaged with a single player.",
     "name_norm": "Boromir",
-    "octgn": "51223bd0-ffd1-11df-a976-0801205c9002"
+    "octgn": "51223bd0-ffd1-11df-a976-0801205c9002",
+    "categories": "Direct Damage, Readying"
   },
   {
-    "name": "Dúnedain Watcher",
+    "name": "D\u00fanedain Watcher",
     "type": "2ally",
     "sphere": "1leadership",
     "cost": 3,
@@ -2330,16 +2369,17 @@
     "no": 96,
     "img": "http://www.cardgamedb.com/forums/uploads/lotr/dunedain-watcher-tdm.jpg",
     "unique": false,
-    "traits": " Dúnedain.",
+    "traits": " D\u00fanedain.",
     "keywords": "",
     "text": "Response: Discard Dunedain Watcher from play to cancel the shadow effects of a card just triggered.",
     "flavor": "`If simple folk are free from care and fear, simple they will be, and we must be secret to keep them so. That has been the task of my kindred, while the years have lengthened and the grass has grown.` -Strider, The Fellowship of the Ring",
     "textc": "Response: Discard Dunedain Watcher from play to cancel the shadow effects of a card just triggered.",
     "name_norm": "Dunedain Watcher",
-    "octgn": "51223bd0-ffd1-11df-a976-0801205c9004"
+    "octgn": "51223bd0-ffd1-11df-a976-0801205c9004",
+    "categories": "Shadow Control"
   },
   {
-    "name": "Dúnedain Cache",
+    "name": "D\u00fanedain Cache",
     "type": "3attachment",
     "sphere": "1leadership",
     "cost": 2,
@@ -2351,10 +2391,10 @@
     "traits": " Item.",
     "keywords": "",
     "text": "Attach to a hero. Attached hero gains ranged.\nAction: Pay 1 resource from attached hero's pool to attach Dunedain Cache to another hero.",
-    "flavor": null,
     "textc": "Attach to a hero. Attached hero gains ranged.\nAction: Pay 1 resource from attached hero's pool to attach Dunedain Cache to another hero.",
     "name_norm": "Dunedain Cache",
-    "octgn": "51223bd0-ffd1-11df-a976-0801205c9003"
+    "octgn": "51223bd0-ffd1-11df-a976-0801205c9003",
+    "categories": ""
   },
   {
     "name": "Vassal of the Windlord",
@@ -2373,10 +2413,10 @@
     "traits": " Creature. Eagle.",
     "keywords": "Ranged.",
     "text": "Vassal of the Windlord cannot have restricted attachments.\nForced: After an attack in which Vassal of the Windlord attacked resolves, discard Vassal of the Windlord from play.",
-    "flavor": null,
     "textc": "Ranged.\nVassal of the Windlord cannot have restricted attachments.\nForced: After an attack in which Vassal of the Windlord attacked resolves, discard Vassal of the Windlord from play.",
     "name_norm": "Vassal of the Windlord",
-    "octgn": "51223bd0-ffd1-11df-a976-0801205c9022"
+    "octgn": "51223bd0-ffd1-11df-a976-0801205c9022",
+    "categories": ""
   },
   {
     "name": "Song of Mocking",
@@ -2394,7 +2434,8 @@
     "flavor": "Old fat spider spinning in a tree!\nOld fat spider can't see me!\nAttercop! Attercop!\nWon't you stop. Stop your spinning and look for me! \n-Bilbo Baggins, The Hobbit ",
     "textc": "Attach to a hero.\nAction: Exhaust Song of Mocking to choose another hero. Until the end of the phase, attached hero takes all damage assigned to the chosen hero.",
     "name_norm": "Song of Mocking",
-    "octgn": "51223bd0-ffd1-11df-a976-0801205c9016"
+    "octgn": "51223bd0-ffd1-11df-a976-0801205c9016",
+    "categories": ""
   },
   {
     "name": "Elfhelm",
@@ -2416,7 +2457,8 @@
     "flavor": "`Buy my lord sends word that we must set ourselves in readiness: orders may come for a sudden move.` -The Return of the King",
     "textc": "While Elfhelm is ready, he gains: 'Response: After your threat is raised as the result of questing unsuccessfully, or by an encounter or quest card effect, reduce your threat by 1.'",
     "name_norm": "Elfhelm",
-    "octgn": "51223bd0-ffd1-11df-a976-0801205c9005"
+    "octgn": "51223bd0-ffd1-11df-a976-0801205c9005",
+    "categories": "Threat Control"
   },
   {
     "name": "We Do Not Sleep",
@@ -2434,7 +2476,8 @@
     "flavor": "`But we must ride more warily; for war is abroad, and the Rohirrim, the Horse-lords, do not sleep, even if it seems so from afar.` -Gandalf, The Two Towers",
     "textc": "Action: Until the end of the phase, Rohan characters do not exhaust to commit to quests.",
     "name_norm": "We Do Not Sleep",
-    "octgn": "51223bd0-ffd1-11df-a976-0801205c9023"
+    "octgn": "51223bd0-ffd1-11df-a976-0801205c9023",
+    "categories": ""
   },
   {
     "name": "Silvan Tracker",
@@ -2456,7 +2499,8 @@
     "flavor": "`The Wood-elves tracked him first, an easy task for them, for his trail was still fresh then.` -Gandalf, The Fellowship of the Rings",
     "textc": "Response: After a Silvan character readies during the refresh phase, heal 1 damage from that character.",
     "name_norm": "Silvan Tracker",
-    "octgn": "51223bd0-ffd1-11df-a976-0801205c9014"
+    "octgn": "51223bd0-ffd1-11df-a976-0801205c9014",
+    "categories": "Healing"
   },
   {
     "name": "Fast Hitch",
@@ -2474,7 +2518,8 @@
     "flavor": "'And I put as fast a hitch over the stump as any one could have done, in the Shire or out of it.' -Sam, The Two Towers",
     "textc": "Attach to a Hobbit character.\nAction: Exhaust Fast Hitch to ready attached character.",
     "name_norm": "Fast Hitch",
-    "octgn": "51223bd0-ffd1-11df-a976-0801205c9006"
+    "octgn": "51223bd0-ffd1-11df-a976-0801205c9006",
+    "categories": "Readying"
   },
   {
     "name": "Song of Battle",
@@ -2492,10 +2537,11 @@
     "flavor": "We go, we go, we go to war, to hew the stone and break the door. -The Two Towers",
     "textc": "Attach to a hero.\nAttached hero gains a Tactics resource icon.",
     "name_norm": "Song of Battle",
-    "octgn": "51223bd0-ffd1-11df-a976-0801205c9015"
+    "octgn": "51223bd0-ffd1-11df-a976-0801205c9015",
+    "categories": "Resource Smoothing"
   },
   {
-    "name": "Dáin Ironfoot",
+    "name": "D\u00e1in Ironfoot",
     "type": "1hero",
     "sphere": "1leadership",
     "cost": 11,
@@ -2514,10 +2560,11 @@
     "flavor": "`You have not heard of Dain and the dwarves of the Iron Hills?` -Bilbo Baggins, The Hobbit",
     "textc": "While Dain Ironfoot is ready, Dwarf characters get +1 Attack and +1 Willpower.",
     "name_norm": "Dain Ironfoot",
-    "octgn": "51223bd0-ffd1-11df-a976-0801206c9005"
+    "octgn": "51223bd0-ffd1-11df-a976-0801206c9005",
+    "categories": "Attack Bonus"
   },
   {
-    "name": "Dúnedain Signal",
+    "name": "D\u00fanedain Signal",
     "type": "3attachment",
     "sphere": "1leadership",
     "cost": 1,
@@ -2529,10 +2576,10 @@
     "traits": " Signal.",
     "keywords": "",
     "text": "Attach to a hero. Attached hero gains sentinel.\nAction: Pay 1 resource from attached hero's pool to attach Dunedain Signal to another hero.",
-    "flavor": null,
     "textc": "Attach to a hero. Attached hero gains sentinel.\nAction: Pay 1 resource from attached hero's pool to attach Dunedain Signal to another hero.",
     "name_norm": "Dunedain Signal",
-    "octgn": "51223bd0-ffd1-11df-a976-0801206c9008"
+    "octgn": "51223bd0-ffd1-11df-a976-0801206c9008",
+    "categories": ""
   },
   {
     "name": "Dawn Take You All",
@@ -2550,7 +2597,8 @@
     "flavor": "`Dawn take you all, and be stone to you!` -Gandalf, The Hobbit",
     "textc": "Play after shadow cards have been dealt, before any attacks have resolved.\nCombat Action: Each player may choose and discard 1 facedown shadow card from an enemy with which he is engaged.",
     "name_norm": "Dawn Take You All",
-    "octgn": "51223bd0-ffd1-11df-a976-0801206c9006"
+    "octgn": "51223bd0-ffd1-11df-a976-0801206c9006",
+    "categories": "Shadow Control"
   },
   {
     "name": "Eagles of the Misty Mountains",
@@ -2569,10 +2617,10 @@
     "traits": " Creature. Eagle.",
     "keywords": "",
     "text": "Eagles of the Misty Mountains cannot have restricted attachments. Eagles of the Misty Mountains gets +1 Attack and +1 Defense for each facedown attachment it has.\nResponse: After another Eagle character leaves play, you may attach that card facedown to Eagles of the Misty Mountains.",
-    "flavor": null,
     "textc": "Eagles of the Misty Mountains cannot have restricted attachments. Eagles of the Misty Mountains gets +1 Attack and +1 Defense for each facedown attachment it has.\nResponse: After another Eagle character leaves play, you may attach that card facedown to Eagles of the Misty Mountains.",
     "name_norm": "Eagles of the Misty Mountains",
-    "octgn": "51223bd0-ffd1-11df-a976-0801206c9009"
+    "octgn": "51223bd0-ffd1-11df-a976-0801206c9009",
+    "categories": "Attack Bonus, Defense Bonus"
   },
   {
     "name": "Support of the Eagles",
@@ -2590,7 +2638,8 @@
     "flavor": "`I would bear you, whither you will, even were you made of stone.` -Gwaihir, The Return of the King",
     "textc": "Attach to a Tactics hero.\nAction: Exhaust Support of the Eagles to choose an Eagle ally. Until the end of the phase, attached hero adds that ally's Attack or Defense (choose 1) to its own.",
     "name_norm": "Support of the Eagles",
-    "octgn": "51223bd0-ffd1-11df-a976-0801206c9019"
+    "octgn": "51223bd0-ffd1-11df-a976-0801206c9019",
+    "categories": ""
   },
   {
     "name": "West Road Traveller",
@@ -2612,7 +2661,8 @@
     "flavor": "The dark world was rushing by, and the wind sang loudly in his ears. -The Return of the King",
     "textc": "Response: After you play West Road Traveller from your hand, switch the active location with any other location in the staging area.",
     "name_norm": "West Road Traveller",
-    "octgn": "51223bd0-ffd1-11df-a976-0801206c9026"
+    "octgn": "51223bd0-ffd1-11df-a976-0801206c9026",
+    "categories": ""
   },
   {
     "name": "Astonishing Speed",
@@ -2630,7 +2680,8 @@
     "flavor": "With astonishing speed and skill they checked their steeds, wheeled, and came charging round. -The Two Towers",
     "textc": "Action: Until the end of the phase, all Rohan characters get +2 Willpower.",
     "name_norm": "Astonishing Speed",
-    "octgn": "51223bd0-ffd1-11df-a976-0801206c9003"
+    "octgn": "51223bd0-ffd1-11df-a976-0801206c9003",
+    "categories": ""
   },
   {
     "name": "Mirkwood Runner",
@@ -2652,7 +2703,8 @@
     "flavor": "`...let a ploughman plough, but choose an otter for swimming, and for running light over grass and leaf or over snow-an Elf.` -Legolas, The Fellowship of the Ring",
     "textc": "While Mirkwood Runner is attacking alone, the defending enemy does not count its Defense.",
     "name_norm": "Mirkwood Runner",
-    "octgn": "51223bd0-ffd1-11df-a976-0801206c9016"
+    "octgn": "51223bd0-ffd1-11df-a976-0801206c9016",
+    "categories": ""
   },
   {
     "name": "Rumour from the Earth",
@@ -2670,7 +2722,8 @@
     "flavor": "'Where sight fails the earth may bring us rumour,' said Aragorn. 'The land must groan under their hated feet.' -The Two Towers",
     "textc": "Action: Look at the top card of the encounter deck. Then, you may pay 1 Lore resource to return Rumour from the Earth to your hand.",
     "name_norm": "Rumour from the Earth",
-    "octgn": "51223bd0-ffd1-11df-a976-0801206c9017"
+    "octgn": "51223bd0-ffd1-11df-a976-0801206c9017",
+    "categories": ""
   },
   {
     "name": "Shadow of the Past",
@@ -2688,7 +2741,8 @@
     "flavor": "The wizard's face remained grave and attentive, and only a flicker in his deep eyes showed that he was startled and indeed alarmed. 'It has been called that before,' he said, 'but not by you.' -The Fellowship of the Ring",
     "textc": "Action: Move the top card of the encounter discard pile to the top of the encounter deck.",
     "name_norm": "Shadow of the Past",
-    "octgn": "51223bd0-ffd1-11df-a976-0801206c9018"
+    "octgn": "51223bd0-ffd1-11df-a976-0801206c9018",
+    "categories": ""
   },
   {
     "name": "Dwalin",
@@ -2707,10 +2761,10 @@
     "traits": " Dwarf.",
     "keywords": "",
     "text": "Response: After Dwalin attacks and destroys an Orc enemy, lower your threat by 2.",
-    "flavor": null,
     "textc": "Response: After Dwalin attacks and destroys an Orc enemy, lower your threat by 2.",
     "name_norm": "Dwalin",
-    "octgn": "51223bd0-ffd1-11df-a976-0801207c9025"
+    "octgn": "51223bd0-ffd1-11df-a976-0801207c9025",
+    "categories": "Threat Control"
   },
   {
     "name": "Bifur",
@@ -2732,7 +2786,8 @@
     "flavor": "`And winter comes after autumn.` - Bifur, The Hobbit",
     "textc": "Action: Pay 1 resource from a hero's resource pool to add 1 resource to Bifur's resource pool. Any player may trigger this ability. (Limit once per round.)",
     "name_norm": "Bifur",
-    "octgn": "51223bd0-ffd1-11df-a976-0801207c9008"
+    "octgn": "51223bd0-ffd1-11df-a976-0801207c9008",
+    "categories": "Resource Acceleration, Resource Smoothing"
   },
   {
     "name": "Narvi's Belt",
@@ -2747,10 +2802,10 @@
     "traits": " Item.",
     "keywords": "",
     "text": "Attach to a Dwarf hero.\nAction: Exhaust Narvi's Belt to give attached hero a Leadership, Lore, Tactics, or Spirit icon until the end of the phase.",
-    "flavor": null,
     "textc": "Attach to a Dwarf hero.\nAction: Exhaust Narvi's Belt to give attached hero a Leadership, Lore, Tactics, or Spirit icon until the end of the phase.",
     "name_norm": "Narvi's Belt",
-    "octgn": "51223bd0-ffd1-11df-a976-0801207c9050"
+    "octgn": "51223bd0-ffd1-11df-a976-0801207c9050",
+    "categories": "Resource Smoothing"
   },
   {
     "name": "Durin's Song",
@@ -2768,7 +2823,8 @@
     "flavor": "A king he was on carven throne\nIn many-pillared halls of stone\nWith golden roof and silver floor,\nAnd runes of power upon the door.\n-The Fellowship of the Ring ",
     "textc": "Action: Choose a Dwarf hero. That hero gets +2 Willpower, +2 Attack, and +2 Defense until the end of the round.",
     "name_norm": "Durin's Song",
-    "octgn": "51223bd0-ffd1-11df-a976-0801207c9024"
+    "octgn": "51223bd0-ffd1-11df-a976-0801207c9024",
+    "categories": "Attack Bonus, Defense Bonus"
   },
   {
     "name": "Ever Onward",
@@ -2783,10 +2839,10 @@
     "traits": "",
     "keywords": "",
     "text": "Response: After players quest unsuccessfully, choose a player. That player does not raise his threat.",
-    "flavor": null,
     "textc": "Response: After players quest unsuccessfully, choose a player. That player does not raise his threat.",
     "name_norm": "Ever Onward",
-    "octgn": "51223bd0-ffd1-11df-a976-0801207c9031"
+    "octgn": "51223bd0-ffd1-11df-a976-0801207c9031",
+    "categories": ""
   },
   {
     "name": "Veteran of Nanduhirion",
@@ -2808,7 +2864,8 @@
     "flavor": "With cries of `Moria!` and `Dain, Dain!` the dwarves of the Iron Hills plunged in... -The Hobbit",
     "textc": "Veteran of Nanduhirion enters play with 1 damage on it.",
     "name_norm": "Veteran of Nanduhirion",
-    "octgn": "51223bd0-ffd1-11df-a976-0801207c9085"
+    "octgn": "51223bd0-ffd1-11df-a976-0801207c9085",
+    "categories": ""
   },
   {
     "name": "Dwarrowdelf Axe",
@@ -2826,10 +2883,11 @@
     "flavor": "`We make good armour and keen swords, but we cannot again make mail or blade to match those that were made before the dragon came.` -Gloin, The Fellowship of the Ring",
     "textc": "Restricted.\nAttach to a Dwarf character.\nAttached character gets +1 Attack.\nResponse: After attached character attacks, deal 1 damage to the defending enemy.",
     "name_norm": "Dwarrowdelf Axe",
-    "octgn": "51223bd0-ffd1-11df-a976-0801207c9026"
+    "octgn": "51223bd0-ffd1-11df-a976-0801207c9026",
+    "categories": "Attack Bonus, Direct Damage"
   },
   {
-    "name": "Khazâd! Khazâd!",
+    "name": "Khaz\u00e2d! Khaz\u00e2d!",
     "type": "4event",
     "sphere": "2tactics",
     "cost": 0,
@@ -2841,10 +2899,10 @@
     "traits": "",
     "keywords": "",
     "text": "Action: Choose a Dwarf character. Until the end of the phase, that character gets +3 Attack.",
-    "flavor": null,
     "textc": "Action: Choose a Dwarf character. Until the end of the phase, that character gets +3 Attack.",
     "name_norm": "Khazad Khazad",
-    "octgn": "51223bd0-ffd1-11df-a976-0801207c9044"
+    "octgn": "51223bd0-ffd1-11df-a976-0801207c9044",
+    "categories": "Attack Bonus"
   },
   {
     "name": "Zigil Miner",
@@ -2863,10 +2921,10 @@
     "traits": " Dwarf.",
     "keywords": "",
     "text": "Action: Exhaust Zigil Miner and name a number to discard the top 2 cards of your deck. If at least one of those cards has cost equal to the named number, choose a hero you control. For each card that matches the named number, add 1 resource to that hero's resource pool.",
-    "flavor": null,
     "textc": "Action: Exhaust Zigil Miner and name a number to discard the top 2 cards of your deck. If at least one of those cards has cost equal to the named number, choose a hero you control. For each card that matches the named number, add 1 resource to that hero's resource pool.",
     "name_norm": "Zigil Miner",
-    "octgn": "51223bd0-ffd1-11df-a976-0801207c9088"
+    "octgn": "51223bd0-ffd1-11df-a976-0801207c9088",
+    "categories": "Resource Acceleration"
   },
   {
     "name": "Untroubled by Darkness",
@@ -2881,10 +2939,10 @@
     "traits": "",
     "keywords": "",
     "text": "Action: Each Dwarf character gets +1 Willpower until the end of the phase. (+2 Willpower instead if the active location is an Underground or Dark location.)",
-    "flavor": null,
     "textc": "Action: Each Dwarf character gets +1 Willpower until the end of the phase. (+2 Willpower instead if the active location is an Underground or Dark location.)",
     "name_norm": "Untroubled by Darkness",
-    "octgn": "51223bd0-ffd1-11df-a976-0801207c9083"
+    "octgn": "51223bd0-ffd1-11df-a976-0801207c9083",
+    "categories": ""
   },
   {
     "name": "Erebor Record Keeper",
@@ -2903,10 +2961,10 @@
     "traits": " Dwarf.",
     "keywords": "",
     "text": "Erebor Record Keeper cannot attack or defend.\n\nAction: Exhaust Erebor Record Keeper and pay 1 Lore resource to choose and ready a Dwarf character.",
-    "flavor": null,
     "textc": "Erebor Record Keeper cannot attack or defend.\n\nAction: Exhaust Erebor Record Keeper and pay 1 Lore resource to choose and ready a Dwarf character.",
     "name_norm": "Erebor Record Keeper",
-    "octgn": "51223bd0-ffd1-11df-a976-0801207c9030"
+    "octgn": "51223bd0-ffd1-11df-a976-0801207c9030",
+    "categories": "Readying"
   },
   {
     "name": "Ancestral Knowledge",
@@ -2921,10 +2979,10 @@
     "traits": "",
     "keywords": "",
     "text": "Action: Exhaust a Dwarf character to place 2 progress tokens on the active location. (4 progress tokens instead if it is an Underground or Mountain location.)",
-    "flavor": null,
     "textc": "Action: Exhaust a Dwarf character to place 2 progress tokens on the active location. (4 progress tokens instead if it is an Underground or Mountain location.)",
     "name_norm": "Ancestral Knowledge",
-    "octgn": "51223bd0-ffd1-11df-a976-0801207c9007"
+    "octgn": "51223bd0-ffd1-11df-a976-0801207c9007",
+    "categories": ""
   },
   {
     "name": "Boots from Erebor",
@@ -2939,10 +2997,10 @@
     "traits": " Item.",
     "keywords": "",
     "text": "Attach to a Dwarf or Hobbit character. Limit 1 Boots from Erebor per character.\nAttached character gets +1 hit point.",
-    "flavor": null,
     "textc": "Attach to a Dwarf or Hobbit character. Limit 1 Boots from Erebor per character.\nAttached character gets +1 hit point.",
     "name_norm": "Boots from Erebor",
-    "octgn": "51223bd0-ffd1-11df-a976-0801207c9012"
+    "octgn": "51223bd0-ffd1-11df-a976-0801207c9012",
+    "categories": "Hit Point Bonus"
   },
   {
     "name": "Elrohir",
@@ -2961,10 +3019,10 @@
     "traits": " Noldor. Noble. Ranger.",
     "keywords": "",
     "text": "While Elladan is in play, Elrohir gets +2 Defense.\n\nResponse: After Elrohir is declared as a defender, pay 1 resource from his resource pool to ready him.",
-    "flavor": null,
     "textc": "While Elladan is in play, Elrohir gets +2 Defense.\n\nResponse: After Elrohir is declared as a defender, pay 1 resource from his resource pool to ready him.",
     "name_norm": "Elrohir",
-    "octgn": "cc7beee8-1f42-4926-8c45-8a50f3a87c57"
+    "octgn": "cc7beee8-1f42-4926-8c45-8a50f3a87c57",
+    "categories": "Readying, Defense Bonus"
   },
   {
     "name": "Taking Initiative",
@@ -2979,10 +3037,10 @@
     "traits": "",
     "keywords": "",
     "text": "Action: Discard the top card of your deck. If the discarded card's printed cost is equal to or higher than the number of characters you control, draw 2 cards and deal 2 damage to any enemy.",
-    "flavor": null,
     "textc": "Action: Discard the top card of your deck. If the discarded card's printed cost is equal to or higher than the number of characters you control, draw 2 cards and deal 2 damage to any enemy.",
     "name_norm": "Taking Initiative",
-    "octgn": "ac2d3796-1d68-4d27-9e5e-4a09a535c0b7"
+    "octgn": "ac2d3796-1d68-4d27-9e5e-4a09a535c0b7",
+    "categories": "Card Draw, Direct Damage"
   },
   {
     "name": "Timely Aid",
@@ -2997,10 +3055,10 @@
     "traits": "",
     "keywords": "Secrecy 3.",
     "text": "Action: Reveal the top 5 cards of your deck and put 1 revealed ally into play, if able. Shuffle all other revealed cards back into your deck.",
-    "flavor": null,
     "textc": "Secrecy 3.\nAction: Reveal the top 5 cards of your deck and put 1 revealed ally into play, if able. Shuffle all other revealed cards back into your deck.",
     "name_norm": "Timely Aid",
-    "octgn": "bd20ff6a-d77f-47d8-81dd-202e5f21cfaf"
+    "octgn": "bd20ff6a-d77f-47d8-81dd-202e5f21cfaf",
+    "categories": "Secrecy"
   },
   {
     "name": "Unseen Strike",
@@ -3015,10 +3073,10 @@
     "traits": "",
     "keywords": "",
     "text": "Action: Choose a character you control. Until the end of the phase, that character gets +3 Attack while attacking an enemy with a higher engagement cost than your threat.",
-    "flavor": null,
     "textc": "Action: Choose a character you control. Until the end of the phase, that character gets +3 Attack while attacking an enemy with a higher engagement cost than your threat.",
     "name_norm": "Unseen Strike",
-    "octgn": "c1c21875-2650-4e7d-b8c7-c0c0970ce8b0"
+    "octgn": "c1c21875-2650-4e7d-b8c7-c0c0970ce8b0",
+    "categories": ""
   },
   {
     "name": "Keeping Count",
@@ -3033,10 +3091,10 @@
     "traits": "",
     "keywords": "",
     "text": "Attach to a hero. Limit 1 per hero.\n\nAttached hero gets +1 Attack for each resource token on another copy of Keeping Count that is above the current number of resource tokens on this card.\n\nForced: After attached hero attacks and destroys an enemy, place 1 resource token on this card.",
-    "flavor": null,
     "textc": "Attach to a hero. Limit 1 per hero.\n\nAttached hero gets +1 Attack for each resource token on another copy of Keeping Count that is above the current number of resource tokens on this card.\n\nForced: After attached hero attacks and destroys an enemy, place 1 resource token on this card.",
     "name_norm": "Keeping Count",
-    "octgn": "fcfc6d7e-40eb-43b4-a72a-b529931f12ea"
+    "octgn": "fcfc6d7e-40eb-43b4-a72a-b529931f12ea",
+    "categories": "Attack Bonus"
   },
   {
     "name": "Bofur",
@@ -3055,10 +3113,10 @@
     "traits": " Dwarf.",
     "keywords": "",
     "text": "Quest Action: Spend 1 Spirit resource to put Bofur into play from your hand, exhausted and committed to a quest. If you quest successfully this phase and Bofur is still in play, return him to your hand.",
-    "flavor": null,
     "textc": "Quest Action: Spend 1 Spirit resource to put Bofur into play from your hand, exhausted and committed to a quest. If you quest successfully this phase and Bofur is still in play, return him to your hand.",
     "name_norm": "Bofur",
-    "octgn": "c00bdeff-c186-4d83-bf24-2142fdd39b19"
+    "octgn": "c00bdeff-c186-4d83-bf24-2142fdd39b19",
+    "categories": ""
   },
   {
     "name": "Renewed Friendship",
@@ -3073,10 +3131,10 @@
     "traits": "",
     "keywords": "",
     "text": "Response: After another player plays an attachment on a hero you control, you may (choose 1): ready 1 of that player's heroes, have that player draw 1 card, or lower that player's threat by 2.",
-    "flavor": null,
     "textc": "Response: After another player plays an attachment on a hero you control, you may (choose 1): ready 1 of that player's heroes, have that player draw 1 card, or lower that player's threat by 2.",
     "name_norm": "Renewed Friendship",
-    "octgn": "ef533832-523e-40ff-9116-163485826c5b"
+    "octgn": "ef533832-523e-40ff-9116-163485826c5b",
+    "categories": "Card Draw, Readying, Threat Control"
   },
   {
     "name": "Ravenhill Scout",
@@ -3098,7 +3156,8 @@
     "flavor": "`They made their first camp on the western side of the great southern spur, which ended in a height called Ravenhill.` -The Hobbit",
     "textc": "Action: Exhaust Ravenhill Scout to move up to 2 progress tokens from 1 location to another location.",
     "name_norm": "Ravenhill Scout",
-    "octgn": "2bb2c224-3d72-455f-9ec6-89670d372660"
+    "octgn": "2bb2c224-3d72-455f-9ec6-89670d372660",
+    "categories": ""
   },
   {
     "name": "Needful to Know",
@@ -3113,10 +3172,10 @@
     "traits": "",
     "keywords": "Secrecy 2.",
     "text": "Action: Raise your threat by 1 to look at the top card of the encounter deck. Then, reduce your threat by X, where X is the threat of that card.",
-    "flavor": null,
     "textc": "Secrecy 2.\nAction: Raise your threat by 1 to look at the top card of the encounter deck. Then, reduce your threat by X, where X is the threat of that card.",
     "name_norm": "Needful to Know",
-    "octgn": "28a27a2b-d9c9-40ab-95ec-b44eca301102"
+    "octgn": "28a27a2b-d9c9-40ab-95ec-b44eca301102",
+    "categories": "Threat Control, Secrecy"
   },
   {
     "name": "Good Meal",
@@ -3131,10 +3190,10 @@
     "traits": "",
     "keywords": "",
     "text": "Attach to a Hobbit hero.\nAction: Discard Good Meal to lower the cost of the next event you play this round that matches attached hero's sphere by 2.",
-    "flavor": null,
     "textc": "Attach to a Hobbit hero.\nAction: Discard Good Meal to lower the cost of the next event you play this round that matches attached hero's sphere by 2.",
     "name_norm": "Good Meal",
-    "octgn": "97016882-11f8-428c-9f3f-43bb51aacb38"
+    "octgn": "97016882-11f8-428c-9f3f-43bb51aacb38",
+    "categories": ""
   },
   {
     "name": "Elladan",
@@ -3153,13 +3212,13 @@
     "traits": " Noldor. Noble. Ranger.",
     "keywords": "",
     "text": "While Elrohir is in play, Elladan gets +2 Attack.\n\nResponse: After Elladan is declared as an attacker, pay 1 resource from his resource pool to ready him.",
-    "flavor": null,
     "textc": "While Elrohir is in play, Elladan gets +2 Attack.\n\nResponse: After Elladan is declared as an attacker, pay 1 resource from his resource pool to ready him.",
     "name_norm": "Elladan",
-    "octgn": "51223bd0-ffd1-11df-a976-0801209c9010"
+    "octgn": "51223bd0-ffd1-11df-a976-0801209c9010",
+    "categories": "Attack Bonus, Readying"
   },
   {
-    "name": "Dúnedain Wanderer",
+    "name": "D\u00fanedain Wanderer",
     "type": "2ally",
     "sphere": "1leadership",
     "cost": 5,
@@ -3172,13 +3231,13 @@
     "no": 29,
     "img": "http://www.cardgamedb.com/forums/uploads/lotr/dunedain-wanderer-rtr.jpg",
     "unique": false,
-    "traits": " Dúnedain. Ranger.",
+    "traits": " D\u00fanedain. Ranger.",
     "keywords": "Ranged.. Sentinel.. Secrecy 3.",
     "text": "",
-    "flavor": null,
     "textc": "Ranged.. Sentinel.. Secrecy 3.\n",
     "name_norm": "Dunedain Wanderer",
-    "octgn": "51223bd0-ffd1-11df-a976-0801209c9009"
+    "octgn": "51223bd0-ffd1-11df-a976-0801209c9009",
+    "categories": ""
   },
   {
     "name": "Lure of Moria",
@@ -3193,10 +3252,10 @@
     "traits": "",
     "keywords": "",
     "text": "Action: Ready all Dwarf characters.",
-    "flavor": null,
     "textc": "Action: Ready all Dwarf characters.",
     "name_norm": "Lure of Moria",
-    "octgn": "51223bd0-ffd1-11df-a976-0801209c9015"
+    "octgn": "51223bd0-ffd1-11df-a976-0801209c9015",
+    "categories": "Readying"
   },
   {
     "name": "Rivendell Blade",
@@ -3211,10 +3270,10 @@
     "traits": " Item. Weapon.",
     "keywords": "Restricted.",
     "text": "Attach to a Noldor or Silvan character.\nWhen attached character attacks an enemy, that enemy gets -2 Defense until the end of the phase.",
-    "flavor": null,
     "textc": "Restricted.\nAttach to a Noldor or Silvan character.\nWhen attached character attacks an enemy, that enemy gets -2 Defense until the end of the phase.",
     "name_norm": "Rivendell Blade",
-    "octgn": "51223bd0-ffd1-11df-a976-0801209c9023"
+    "octgn": "51223bd0-ffd1-11df-a976-0801209c9023",
+    "categories": ""
   },
   {
     "name": "Hail of Stones",
@@ -3229,10 +3288,10 @@
     "traits": "",
     "keywords": "",
     "text": "Action: Exhaust X characters to deal X damage to an enemy in the staging area.",
-    "flavor": null,
     "textc": "Action: Exhaust X characters to deal X damage to an enemy in the staging area.",
     "name_norm": "Hail of Stones",
-    "octgn": "51223bd0-ffd1-11df-a976-0801209c9014"
+    "octgn": "51223bd0-ffd1-11df-a976-0801209c9014",
+    "categories": "Direct Damage"
   },
   {
     "name": "Rider of the Mark",
@@ -3251,13 +3310,13 @@
     "traits": " Rohan.",
     "keywords": "",
     "text": "Action: Spend 1 Spirit resource to give control of Rider of the Mark to another player. (Limit once per round.)Response: After Rider of the Mark changes control, discard a shadow card dealt to an enemy you are engaged with.",
-    "flavor": null,
     "textc": "Action: Spend 1 Spirit resource to give control of Rider of the Mark to another player. (Limit once per round.)Response: After Rider of the Mark changes control, discard a shadow card dealt to an enemy you are engaged with.",
     "name_norm": "Rider of the Mark",
-    "octgn": "51223bd0-ffd1-11df-a976-0801209c9022"
+    "octgn": "51223bd0-ffd1-11df-a976-0801209c9022",
+    "categories": "Shadow Control"
   },
   {
-    "name": "Song of Eärendil",
+    "name": "Song of E\u00e4rendil",
     "type": "3attachment",
     "sphere": "3spirit",
     "cost": 1,
@@ -3268,11 +3327,11 @@
     "unique": false,
     "traits": " Song.",
     "keywords": "",
-    "text": "Attach to a Spirit hero.\n\nResponse: After Song of Eärendil enters play, draw 1 card.\n                \nResponse: After another player raises his threat, raise your threat by 1 to reduce that player's threat by 1.",
-    "flavor": null,
-    "textc": "Attach to a Spirit hero.\n\nResponse: After Song of Eärendil enters play, draw 1 card.\n                \nResponse: After another player raises his threat, raise your threat by 1 to reduce that player's threat by 1.",
+    "text": "Attach to a Spirit hero.\n\nResponse: After Song of E\u00e4rendil enters play, draw 1 card.\n                \nResponse: After another player raises his threat, raise your threat by 1 to reduce that player's threat by 1.",
+    "textc": "Attach to a Spirit hero.\n\nResponse: After Song of E\u00e4rendil enters play, draw 1 card.\n                \nResponse: After another player raises his threat, raise your threat by 1 to reduce that player's threat by 1.",
     "name_norm": "Song of Earendil",
-    "octgn": "51223bd0-ffd1-11df-a976-0801209c9026"
+    "octgn": "51223bd0-ffd1-11df-a976-0801209c9026",
+    "categories": "Card Draw, Threat Control"
   },
   {
     "name": "Bombur",
@@ -3291,10 +3350,10 @@
     "traits": " Dwarf.",
     "keywords": "",
     "text": "Action: Exhaust Bombur to choose a location. That location gets -1 Threat until the end of the phase. (That location does not contribute its Threat instead if it is an Underground location.)",
-    "flavor": null,
     "textc": "Action: Exhaust Bombur to choose a location. That location gets -1 Threat until the end of the phase. (That location does not contribute its Threat instead if it is an Underground location.)",
     "name_norm": "Bombur",
-    "octgn": "51223bd0-ffd1-11df-a976-0801209c9007"
+    "octgn": "51223bd0-ffd1-11df-a976-0801209c9007",
+    "categories": ""
   },
   {
     "name": "Out of the Wild",
@@ -3309,10 +3368,10 @@
     "traits": "",
     "keywords": "Secrecy 2.",
     "text": "Action: Search the top 5 cards of the encounter deck for any 1 non-objective card worth no victory points and add it to your victory display. Shuffle the encounter deck.",
-    "flavor": null,
     "textc": "Secrecy 2.\nAction: Search the top 5 cards of the encounter deck for any 1 non-objective card worth no victory points and add it to your victory display. Shuffle the encounter deck.",
     "name_norm": "Out of the Wild",
-    "octgn": "51223bd0-ffd1-11df-a976-0801209c9020"
+    "octgn": "51223bd0-ffd1-11df-a976-0801209c9020",
+    "categories": "Secrecy"
   },
   {
     "name": "The End Comes",
@@ -3327,10 +3386,10 @@
     "traits": "",
     "keywords": "",
     "text": "Response: After a Dwarf character leaves play, shuffle the encounter discard pile back into the encounter deck.",
-    "flavor": null,
     "textc": "Response: After a Dwarf character leaves play, shuffle the encounter discard pile back into the encounter deck.",
     "name_norm": "The End Comes",
-    "octgn": "51223bd0-ffd1-11df-a976-0801209c9027"
+    "octgn": "51223bd0-ffd1-11df-a976-0801209c9027",
+    "categories": ""
   },
   {
     "name": "Aragorn",
@@ -3346,13 +3405,13 @@
     "no": 53,
     "img": "http://www.cardgamedb.com/forums/uploads/lotr/aragorn-twitw.jpg",
     "unique": true,
-    "traits": " Dúnedain. Ranger.",
+    "traits": " D\u00fanedain. Ranger.",
     "keywords": "Sentinel.",
     "text": "Refresh Action: Reduce your threat to your starting threat level. (Limit once per game.)",
-    "flavor": null,
     "textc": "Sentinel.\nRefresh Action: Reduce your threat to your starting threat level. (Limit once per game.)",
     "name_norm": "Aragorn",
-    "octgn": "51223bd0-ffd1-11df-a976-0801210c9001"
+    "octgn": "51223bd0-ffd1-11df-a976-0801210c9001",
+    "categories": "Threat Control"
   },
   {
     "name": "Grave Cairn",
@@ -3367,10 +3426,10 @@
     "traits": "",
     "keywords": "",
     "text": "Response: After a character leaves play, add its Attack to another character's Attack until the end of the round.",
-    "flavor": null,
     "textc": "Response: After a character leaves play, add its Attack to another character's Attack until the end of the round.",
     "name_norm": "Grave Cairn",
-    "octgn": "51223bd0-ffd1-11df-a976-0801210c9007"
+    "octgn": "51223bd0-ffd1-11df-a976-0801210c9007",
+    "categories": "Attack Bonus"
   },
   {
     "name": "Sword that was Broken",
@@ -3385,10 +3444,10 @@
     "traits": " Artifact.",
     "keywords": "",
     "text": "Attach to a hero. Attached hero gains a Leadership resource icon.\nIf attached hero is Aragorn, each character you control gets +1 Willpower.",
-    "flavor": null,
     "textc": "Attach to a hero. Attached hero gains a Leadership resource icon.\nIf attached hero is Aragorn, each character you control gets +1 Willpower.",
     "name_norm": "Sword that was Broken",
-    "octgn": "51223bd0-ffd1-11df-a976-0801210c9018"
+    "octgn": "51223bd0-ffd1-11df-a976-0801210c9018",
+    "categories": "Resource Smoothing"
   },
   {
     "name": "Watcher of the Bruinen",
@@ -3407,10 +3466,10 @@
     "traits": " Noldor. Warrior.",
     "keywords": "Sentinel.",
     "text": "Watcher of the Bruinen does not exhaust to defend.\nForced: After Watcher of the Bruinen defends, either discard it from play or discard 1 card from your hand.",
-    "flavor": null,
     "textc": "Sentinel.\nWatcher of the Bruinen does not exhaust to defend.\nForced: After Watcher of the Bruinen defends, either discard it from play or discard 1 card from your hand.",
     "name_norm": "Watcher of the Bruinen",
-    "octgn": "51223bd0-ffd1-11df-a976-0801210c9025"
+    "octgn": "51223bd0-ffd1-11df-a976-0801210c9025",
+    "categories": ""
   },
   {
     "name": "Rivendell Bow",
@@ -3425,13 +3484,13 @@
     "traits": " Item. Weapon.",
     "keywords": "",
     "text": "Attach to a Noldor or Silvan character, or to Aragorn. Limit 1 per character.\nAttached character gains ranged.If attached character has a printed ranged keyword, it gets +1 Attack during a ranged attack.",
-    "flavor": null,
     "textc": "Attach to a Noldor or Silvan character, or to Aragorn. Limit 1 per character.\nAttached character gains ranged.If attached character has a printed ranged keyword, it gets +1 Attack during a ranged attack.",
     "name_norm": "Rivendell Bow",
-    "octgn": "51223bd0-ffd1-11df-a976-0801210c9013"
+    "octgn": "51223bd0-ffd1-11df-a976-0801210c9013",
+    "categories": ""
   },
   {
-    "name": "Arwen Undómiel",
+    "name": "Arwen Und\u00f3miel",
     "type": "2ally",
     "sphere": "3spirit",
     "cost": 2,
@@ -3446,11 +3505,11 @@
     "unique": true,
     "traits": " Noldor. Noble.",
     "keywords": "",
-    "text": "Response: After Arwen Undómiel exhausts, choose a character. That character gains sentinel and gets +1 Defense until the end of the round.",
-    "flavor": null,
-    "textc": "Response: After Arwen Undómiel exhausts, choose a character. That character gains sentinel and gets +1 Defense until the end of the round.",
+    "text": "Response: After Arwen Und\u00f3miel exhausts, choose a character. That character gains sentinel and gets +1 Defense until the end of the round.",
+    "textc": "Response: After Arwen Und\u00f3miel exhausts, choose a character. That character gains sentinel and gets +1 Defense until the end of the round.",
     "name_norm": "Arwen Undomiel",
-    "octgn": "51223bd0-ffd1-11df-a976-0801210c9002"
+    "octgn": "51223bd0-ffd1-11df-a976-0801210c9002",
+    "categories": "Defense Bonus"
   },
   {
     "name": "Elrond's Counsel",
@@ -3465,10 +3524,10 @@
     "traits": "",
     "keywords": "",
     "text": "Action: If you control a unique Noldor character, give another character +1 Willpower until the end of the phase and lower your threat by 3.",
-    "flavor": null,
     "textc": "Action: If you control a unique Noldor character, give another character +1 Willpower until the end of the phase and lower your threat by 3.",
     "name_norm": "Elrond's Counsel",
-    "octgn": "51223bd0-ffd1-11df-a976-0801210c9005"
+    "octgn": "51223bd0-ffd1-11df-a976-0801210c9005",
+    "categories": "Threat Control"
   },
   {
     "name": "Short Cut",
@@ -3483,10 +3542,10 @@
     "traits": "",
     "keywords": "",
     "text": "Response: After a location enters play, exhaust a Hobbit character to shuffle that location back into the encounter deck. Then, reveal 1 card from the encounter deck and add it to the staging area.",
-    "flavor": null,
     "textc": "Response: After a location enters play, exhaust a Hobbit character to shuffle that location back into the encounter deck. Then, reveal 1 card from the encounter deck and add it to the staging area.",
     "name_norm": "Short Cut",
-    "octgn": "51223bd0-ffd1-11df-a976-0801210c9014"
+    "octgn": "51223bd0-ffd1-11df-a976-0801210c9014",
+    "categories": ""
   },
   {
     "name": "Legacy of Durin",
@@ -3501,10 +3560,10 @@
     "traits": " Condition.",
     "keywords": "",
     "text": "Attach to a Dwarf hero.\nResponse: After you play a Dwarf character from your hand, draw 1 card.",
-    "flavor": null,
     "textc": "Attach to a Dwarf hero.\nResponse: After you play a Dwarf character from your hand, draw 1 card.",
     "name_norm": "Legacy of Durin",
-    "octgn": "51223bd0-ffd1-11df-a976-0801210c9009"
+    "octgn": "51223bd0-ffd1-11df-a976-0801210c9009",
+    "categories": "Card Draw"
   },
   {
     "name": "Resourceful",
@@ -3519,13 +3578,13 @@
     "traits": "",
     "keywords": "Secrecy 3.",
     "text": "Attach to a hero you control.\nAttached hero collects 1 additional resource during the resource phase each round.",
-    "flavor": null,
     "textc": "Secrecy 3.\nAttach to a hero you control.\nAttached hero collects 1 additional resource during the resource phase each round.",
     "name_norm": "Resourceful",
-    "octgn": "51223bd0-ffd1-11df-a976-0801210c9012"
+    "octgn": "51223bd0-ffd1-11df-a976-0801210c9012",
+    "categories": "Secrecy"
   },
   {
-    "name": "Háma",
+    "name": "H\u00e1ma",
     "type": "1hero",
     "sphere": "2tactics",
     "cost": 9,
@@ -3541,10 +3600,10 @@
     "traits": " Rohan. Warrior.",
     "keywords": "",
     "text": "Response: After Hama is declared as an attacker, return a Tactics event from your discard pile to your hand. Then, choose and discard 1 card from your hand.",
-    "flavor": null,
     "textc": "Response: After Hama is declared as an attacker, return a Tactics event from your discard pile to your hand. Then, choose and discard 1 card from your hand.",
     "name_norm": "Hama",
-    "octgn": "51223bd0-ffd1-11df-a976-0801211c9016"
+    "octgn": "51223bd0-ffd1-11df-a976-0801211c9016",
+    "categories": ""
   },
   {
     "name": "Erestor",
@@ -3563,10 +3622,10 @@
     "traits": " Noldor.",
     "keywords": "",
     "text": "Action: Choose and discard 1 card from your hand to draw 1 card. (Limit once per round.)",
-    "flavor": null,
     "textc": "Action: Choose and discard 1 card from your hand to draw 1 card. (Limit once per round.)",
     "name_norm": "Erestor",
-    "octgn": "51223bd0-ffd1-11df-a976-0801211c9008"
+    "octgn": "51223bd0-ffd1-11df-a976-0801211c9008",
+    "categories": "Card Draw"
   },
   {
     "name": "Fresh Tracks",
@@ -3581,10 +3640,10 @@
     "traits": "",
     "keywords": "",
     "text": "Response: After an enemy is added to the staging area, deal 1 damage to that enemy. Players ignore that enemy while making engagement checks this round.",
-    "flavor": null,
     "textc": "Response: After an enemy is added to the staging area, deal 1 damage to that enemy. Players ignore that enemy while making engagement checks this round.",
     "name_norm": "Fresh Tracks",
-    "octgn": "51223bd0-ffd1-11df-a976-0801211c9012"
+    "octgn": "51223bd0-ffd1-11df-a976-0801211c9012",
+    "categories": "Direct Damage"
   },
   {
     "name": "Erebor Battle Master",
@@ -3603,10 +3662,10 @@
     "traits": " Dwarf. Warrior.",
     "keywords": "",
     "text": "Erebor Battle Master gets +1 Attack for each other Dwarf ally you control.",
-    "flavor": null,
     "textc": "Erebor Battle Master gets +1 Attack for each other Dwarf ally you control.",
     "name_norm": "Erebor Battle Master",
-    "octgn": "51223bd0-ffd1-11df-a976-0801211c9007"
+    "octgn": "51223bd0-ffd1-11df-a976-0801211c9007",
+    "categories": "Attack Bonus"
   },
   {
     "name": "Ring Mail",
@@ -3621,10 +3680,10 @@
     "traits": " Item. Armor.",
     "keywords": "Restricted.",
     "text": "Attach to a Dwarf or Hobbit character.\nAttached character gets +1 hit point and +1 Defense.",
-    "flavor": null,
     "textc": "Restricted.\nAttach to a Dwarf or Hobbit character.\nAttached character gets +1 hit point and +1 Defense.",
     "name_norm": "Ring Mail",
-    "octgn": "51223bd0-ffd1-11df-a976-0801211c9021"
+    "octgn": "51223bd0-ffd1-11df-a976-0801211c9021",
+    "categories": "Defense Bonus, Hit Point Bonus"
   },
   {
     "name": "Out of Sight",
@@ -3639,10 +3698,10 @@
     "traits": "",
     "keywords": "Secrecy 3.",
     "text": "Action: Enemies engaged with you cannot attack you this phase.",
-    "flavor": null,
     "textc": "Secrecy 3.\nAction: Enemies engaged with you cannot attack you this phase.",
     "name_norm": "Out of Sight",
-    "octgn": "51223bd0-ffd1-11df-a976-0801211c9020"
+    "octgn": "51223bd0-ffd1-11df-a976-0801211c9020",
+    "categories": "Combat Control, Secrecy"
   },
   {
     "name": "Ever My Heart Rises",
@@ -3657,10 +3716,10 @@
     "traits": " Condition.",
     "keywords": "",
     "text": "Attach to a Dwarf character.\nResponse: After you travel to a Mountain or Underground location, ready attached character and reduce your threat by 1.",
-    "flavor": null,
     "textc": "Attach to a Dwarf character.\nResponse: After you travel to a Mountain or Underground location, ready attached character and reduce your threat by 1.",
     "name_norm": "Ever My Heart Rises",
-    "octgn": "51223bd0-ffd1-11df-a976-0801211c9009"
+    "octgn": "51223bd0-ffd1-11df-a976-0801211c9009",
+    "categories": "Readying, Threat Control"
   },
   {
     "name": "Warden of Healing",
@@ -3682,7 +3741,8 @@
     "flavor": "`But for long years we healers have only sought to patch the rents made by the men of swords.` -Return of the King",
     "textc": "Action: Exhaust Warden of Healing to heal 1 damage on up to 2 different characters. Then, you may pay 2 Lore resources to ready Warden of Healing.",
     "name_norm": "Warden of Healing",
-    "octgn": "51223bd0-ffd1-11df-a976-0801211c9026"
+    "octgn": "51223bd0-ffd1-11df-a976-0801211c9026",
+    "categories": "Healing"
   },
   {
     "name": "Word of Command",
@@ -3700,7 +3760,8 @@
     "flavor": "`Picking up a faggot he held it aloft for a moment, and then with a word of command, naur an edraith ammen! he thrust the end of his staff into the midst of it. At once a great spout of green and blue flame sprang out, and the wood flared and sputtered.` -The Fellowship of the Ring",
     "textc": "Action: Exhaust an Istari character to search your deck for 1 card and add it to your hand. Shuffle your deck.",
     "name_norm": "Word of Command",
-    "octgn": "51223bd0-ffd1-11df-a976-0801211c9027"
+    "octgn": "51223bd0-ffd1-11df-a976-0801211c9027",
+    "categories": "Card Search"
   },
   {
     "name": "Love of Tales",
@@ -3715,10 +3776,10 @@
     "traits": " Condition.",
     "keywords": "",
     "text": "Attach to a Lore hero. Limit 1 per hero.\nResponse: After a Song card is played, exhaust Love of Tales to add 1 resource to attached hero's resource pool.",
-    "flavor": null,
     "textc": "Attach to a Lore hero. Limit 1 per hero.\nResponse: After a Song card is played, exhaust Love of Tales to add 1 resource to attached hero's resource pool.",
     "name_norm": "Love of Tales",
-    "octgn": "51223bd0-ffd1-11df-a976-0801211c9019"
+    "octgn": "51223bd0-ffd1-11df-a976-0801211c9019",
+    "categories": "Resource Acceleration"
   },
   {
     "name": "Glorfindel",
@@ -3737,10 +3798,11 @@
     "traits": " Noldor. Noble. Warrior.",
     "keywords": "",
     "text": "Forced: After Glorfindel exhausts to commit to a quest, raise your threat by 1.",
-    "flavor": "Glorfindel was tall and straight; his hair was of shining gold, his face fair and young and fearless and full of joy; his eyes were bright and keen, and has voice like music; on his brow sat wisdom, and in his hand was strength.\r\n-The Fellowship of the Ring",
+    "flavor": "Glorfindel was tall and straight; his hair was of shining gold, his face fair and young and fearless and full of joy; his eyes were bright and keen, and has voice like music; on his brow sat wisdom, and in his hand was strength.\n-The Fellowship of the Ring",
     "textc": "Forced: After Glorfindel exhausts to commit to a quest, raise your threat by 1.",
     "name_norm": "Glorfindel",
-    "octgn": "51223bd0-ffd1-11df-a976-0801212c9016"
+    "octgn": "51223bd0-ffd1-11df-a976-0801212c9016",
+    "categories": ""
   },
   {
     "name": "Longbeard Elder",
@@ -3759,10 +3821,10 @@
     "traits": " Dwarf.",
     "keywords": "",
     "text": "Response: After Longbeard Elder commits to a quest, look at the top card of the encounter deck. If that card is a location, place 1 progress token on the current quest. Otherwise, Longbeard Elder gets -1 Willpower until the end of the phase.",
-    "flavor": null,
     "textc": "Response: After Longbeard Elder commits to a quest, look at the top card of the encounter deck. If that card is a location, place 1 progress token on the current quest. Otherwise, Longbeard Elder gets -1 Willpower until the end of the phase.",
     "name_norm": "Longbeard Elder",
-    "octgn": "51223bd0-ffd1-11df-a976-0801212c9021"
+    "octgn": "51223bd0-ffd1-11df-a976-0801212c9021",
+    "categories": ""
   },
   {
     "name": "Path of Need",
@@ -3778,10 +3840,10 @@
     "traits": " Condition.",
     "keywords": "",
     "text": "Limit 1 per deck. Attach to a location. Heroes do not exhaust to attack, defend, or commit to a quest while attached location is the active location.",
-    "flavor": null,
     "textc": "Limit 1 per deck. Attach to a location. Heroes do not exhaust to attack, defend, or commit to a quest while attached location is the active location.",
     "name_norm": "Path of Need",
-    "octgn": "51223bd0-ffd1-11df-a976-0801212c9028"
+    "octgn": "51223bd0-ffd1-11df-a976-0801212c9028",
+    "categories": ""
   },
   {
     "name": "Trollshaw Scout",
@@ -3800,10 +3862,10 @@
     "traits": " Noldor. Scout.",
     "keywords": "Ranged.",
     "text": "Trollshaw Scout does not exhaust to attack.\nForced: After Trollshaw Scout attacks, either discard it from play or discard 1 card from your hand.",
-    "flavor": null,
     "textc": "Ranged.\nTrollshaw Scout does not exhaust to attack.\nForced: After Trollshaw Scout attacks, either discard it from play or discard 1 card from your hand.",
     "name_norm": "Trollshaw Scout",
-    "octgn": "51223bd0-ffd1-11df-a976-0801212c9033"
+    "octgn": "51223bd0-ffd1-11df-a976-0801212c9033",
+    "categories": ""
   },
   {
     "name": "Heavy Stroke",
@@ -3821,7 +3883,8 @@
     "flavor": "`Beside them Gimli stood with his stout legs apart, wielding his dwarf-axe.` -The Fellowship of the Ring",
     "textc": "Response: After a Dwarf deals X damage to an enemy during combat, deal an additional X damage to that enemy. (Limit once per phase.)",
     "name_norm": "Heavy Stroke",
-    "octgn": "51223bd0-ffd1-11df-a976-0801212c9018"
+    "octgn": "51223bd0-ffd1-11df-a976-0801212c9018",
+    "categories": "Direct Damage"
   },
   {
     "name": "Imladris Stargazer",
@@ -3840,10 +3903,10 @@
     "traits": " Noldor.",
     "keywords": "",
     "text": "Action: Exhaust Imladris Stargazer to choose a player. That player looks at the top 5 cards of his deck and then returns them to the top of his deck in any order.",
-    "flavor": null,
     "textc": "Action: Exhaust Imladris Stargazer to choose a player. That player looks at the top 5 cards of his deck and then returns them to the top of his deck in any order.",
     "name_norm": "Imladris Stargazer",
-    "octgn": "51223bd0-ffd1-11df-a976-0801212c9019"
+    "octgn": "51223bd0-ffd1-11df-a976-0801212c9019",
+    "categories": ""
   },
   {
     "name": "Light of Valinor",
@@ -3858,10 +3921,11 @@
     "traits": " Condition.",
     "keywords": "",
     "text": "Attach to a Noldor or Silvan hero.\nAttached hero does not exhaust to commit to a quest.",
-    "flavor": "`... those who have dwelt in the blassed realm live at once in both worlds, and against both the Seen and Unseen they have great power.`\r\n-Gandalf, The Fellowship of the Ring",
+    "flavor": "`... those who have dwelt in the blassed realm live at once in both worlds, and against both the Seen and Unseen they have great power.`\n-Gandalf, The Fellowship of the Ring",
     "textc": "Attach to a Noldor or Silvan hero.\nAttached hero does not exhaust to commit to a quest.",
     "name_norm": "Light of Valinor",
-    "octgn": "51223bd0-ffd1-11df-a976-0801212c9020"
+    "octgn": "51223bd0-ffd1-11df-a976-0801212c9020",
+    "categories": ""
   },
   {
     "name": "Daeron's Runes",
@@ -3876,10 +3940,11 @@
     "traits": "",
     "keywords": "",
     "text": "Action: Draw 2 cards. Then, discard 1 card from your hand.",
-    "flavor": "`These are Daeron's Runes, such as were used of old in Moria...`\r\n-Gandalf, The Fellowship of the Ring",
+    "flavor": "`These are Daeron's Runes, such as were used of old in Moria...`\n-Gandalf, The Fellowship of the Ring",
     "textc": "Action: Draw 2 cards. Then, discard 1 card from your hand.",
     "name_norm": "Daeron's Runes",
-    "octgn": "51223bd0-ffd1-11df-a976-0801212c9010"
+    "octgn": "51223bd0-ffd1-11df-a976-0801212c9010",
+    "categories": "Card Draw"
   },
   {
     "name": "Healing Herbs",
@@ -3894,10 +3959,10 @@
     "traits": "",
     "keywords": "",
     "text": "Attach to a Lore hero.\nAction: Discard Healing Herbs and exhaust attached hero to heal all damage on 1 character.",
-    "flavor": null,
     "textc": "Attach to a Lore hero.\nAction: Discard Healing Herbs and exhaust attached hero to heal all damage on 1 character.",
     "name_norm": "Healing Herbs",
-    "octgn": "51223bd0-ffd1-11df-a976-0801212c9017"
+    "octgn": "51223bd0-ffd1-11df-a976-0801212c9017",
+    "categories": "Healing"
   },
   {
     "name": "Asfaloth",
@@ -3915,7 +3980,8 @@
     "flavor": "Suddenly into view below came a white horse, gleaming in the shadows, running swiftly. In the dusk its headstall flickered and flashed as if it were studded with gems like living stars. -The Fellowship of the Ring",
     "textc": "Attach to a Noldor or Silvan hero.\nAction: Exhaust Asfaloth to place 1 progress token on any location. (2 tokens instead if attached hero is Glorfindel.)",
     "name_norm": "Asfaloth",
-    "octgn": "51223bd0-ffd1-11df-a976-0801212c9001"
+    "octgn": "51223bd0-ffd1-11df-a976-0801212c9001",
+    "categories": ""
   },
   {
     "name": "Elrond",
@@ -3934,10 +4000,10 @@
     "traits": " Noldor. Noble.",
     "keywords": "",
     "text": "You may spend resources from Elrond's resource pool to pay for Spirit, Leadership, and Tactics allies.\nResponse: After a character is healed by another card effect, heal 1 damage on it.",
-    "flavor": null,
     "textc": "You may spend resources from Elrond's resource pool to pay for Spirit, Leadership, and Tactics allies.\nResponse: After a character is healed by another card effect, heal 1 damage on it.",
     "name_norm": "Elrond",
-    "octgn": "51223bd0-ffd1-11df-a976-0801213c9004"
+    "octgn": "51223bd0-ffd1-11df-a976-0801213c9004",
+    "categories": "Healing"
   },
   {
     "name": "We Are Not Idle",
@@ -3952,10 +4018,11 @@
     "traits": "",
     "keywords": "",
     "text": "Action: Exhaust X Dwarf characters to add X resources to a hero's resource pool and draw 1 card.",
-    "flavor": "`You should see the stone-paved roads of many colours! And the halls and cavernous streets under the earth with arches carved like trees; and the terraces and towers upon the Mountain's sides! Then you would see that we have not been idle.` -Glóin, The Fellowship of the Ring",
+    "flavor": "`You should see the stone-paved roads of many colours! And the halls and cavernous streets under the earth with arches carved like trees; and the terraces and towers upon the Mountain's sides! Then you would see that we have not been idle.` -Gl\u00f3in, The Fellowship of the Ring",
     "textc": "Action: Exhaust X Dwarf characters to add X resources to a hero's resource pool and draw 1 card.",
     "name_norm": "We Are Not Idle",
-    "octgn": "51223bd0-ffd1-11df-a976-0801213c9028"
+    "octgn": "51223bd0-ffd1-11df-a976-0801213c9028",
+    "categories": "Card Draw"
   },
   {
     "name": "Hardy Leadership",
@@ -3970,10 +4037,10 @@
     "traits": "",
     "keywords": "",
     "text": "Attach to a Leadership hero.\nEach Dwarf character gets +1 hit point.",
-    "flavor": null,
     "textc": "Attach to a Leadership hero.\nEach Dwarf character gets +1 hit point.",
     "name_norm": "Hardy Leadership",
-    "octgn": "51223bd0-ffd1-11df-a976-0801213c9008"
+    "octgn": "51223bd0-ffd1-11df-a976-0801213c9008",
+    "categories": "Hit Point Bonus"
   },
   {
     "name": "Hands Upon the Bow",
@@ -3988,10 +4055,10 @@
     "traits": "",
     "keywords": "",
     "text": "Action: Exhaust a character you control with ranged to immediately declare it as an attacker (and resolve its attack) against an enemy in the staging area. It gets +1 Attack during this attack.",
-    "flavor": null,
     "textc": "Action: Exhaust a character you control with ranged to immediately declare it as an attacker (and resolve its attack) against an enemy in the staging area. It gets +1 Attack during this attack.",
     "name_norm": "Hands Upon the Bow",
-    "octgn": "51223bd0-ffd1-11df-a976-0801213c9007"
+    "octgn": "51223bd0-ffd1-11df-a976-0801213c9007",
+    "categories": "Attack Bonus"
   },
   {
     "name": "O Elbereth! Gilthonial!",
@@ -4006,10 +4073,10 @@
     "traits": "",
     "keywords": "Secrecy 4.",
     "text": "Response: After an enemy attacks you, put that enemy on the bottom of the encounter deck. If your threat is lower than that enemy's engagement cost, set your threat equal to the engagement cost of that enemy.",
-    "flavor": null,
     "textc": "Secrecy 4.\nResponse: After an enemy attacks you, put that enemy on the bottom of the encounter deck. If your threat is lower than that enemy's engagement cost, set your threat equal to the engagement cost of that enemy.",
     "name_norm": "O Elbereth Gilthonial",
-    "octgn": "51223bd0-ffd1-11df-a976-0801213c9019"
+    "octgn": "51223bd0-ffd1-11df-a976-0801213c9019",
+    "categories": "Secrecy"
   },
   {
     "name": "Miruvor",
@@ -4024,10 +4091,10 @@
     "traits": " Item.",
     "keywords": "",
     "text": "Attach to a hero.\nAction: Discard Miruvor to (choose two): ready attached hero, add 1 resource to attached hero's resource pool, attached hero gets +1 Willpower until the end of the round, or put Miruvor on the top of your deck.",
-    "flavor": null,
     "textc": "Attach to a hero.\nAction: Discard Miruvor to (choose two): ready attached hero, add 1 resource to attached hero's resource pool, attached hero gets +1 Willpower until the end of the round, or put Miruvor on the top of your deck.",
     "name_norm": "Miruvor",
-    "octgn": "51223bd0-ffd1-11df-a976-0801213c9016"
+    "octgn": "51223bd0-ffd1-11df-a976-0801213c9016",
+    "categories": "Readying, Resource Acceleration"
   },
   {
     "name": "Master of the Forge",
@@ -4046,10 +4113,10 @@
     "traits": " Noldor. Craftsman.",
     "keywords": "",
     "text": "Action: Exhaust Master of the Forge to search the top 5 cards of your deck for any 1 attachment and add it to your hand. Shuffle the other cards back into your deck.",
-    "flavor": null,
     "textc": "Action: Exhaust Master of the Forge to search the top 5 cards of your deck for any 1 attachment and add it to your hand. Shuffle the other cards back into your deck.",
     "name_norm": "Master of the Forge",
-    "octgn": "51223bd0-ffd1-11df-a976-0801213c9015"
+    "octgn": "51223bd0-ffd1-11df-a976-0801213c9015",
+    "categories": "Card Search"
   },
   {
     "name": "Peace, and Thought",
@@ -4064,10 +4131,10 @@
     "traits": "",
     "keywords": "",
     "text": "Refresh Action: Exhaust 2 heroes to draw 5 cards.",
-    "flavor": null,
     "textc": "Refresh Action: Exhaust 2 heroes to draw 5 cards.",
     "name_norm": "Peace, and Thought",
-    "octgn": "51223bd0-ffd1-11df-a976-0801213c9020"
+    "octgn": "51223bd0-ffd1-11df-a976-0801213c9020",
+    "categories": "Card Draw"
   },
   {
     "name": "Risk Some Light",
@@ -4082,10 +4149,10 @@
     "traits": "",
     "keywords": "Secrecy 3.",
     "text": "Action: Look at the top 3 cards of the encounter deck. You may select 1 card and move it to the bottom of the encounter deck. Return any unselected cards to the top of the encounter deck, in any order.",
-    "flavor": null,
     "textc": "Secrecy 3.\nAction: Look at the top 3 cards of the encounter deck. You may select 1 card and move it to the bottom of the encounter deck. Return any unselected cards to the top of the encounter deck, in any order.",
     "name_norm": "Risk Some Light",
-    "octgn": "51223bd0-ffd1-11df-a976-0801213c9022"
+    "octgn": "51223bd0-ffd1-11df-a976-0801213c9022",
+    "categories": "Secrecy"
   },
   {
     "name": "Vilya",
@@ -4100,10 +4167,10 @@
     "traits": " Ring. Artifact.",
     "keywords": "",
     "text": "Attach to Elrond. He gains a Spirit resource icon.\nAction: Exhaust Elrond and Vilya to reveal the top card of your deck. You can immediately play or put into play the revealed card for no cost, if able. Otherwise, move the revealed card to the bottom of your deck.",
-    "flavor": null,
     "textc": "Attach to Elrond. He gains a Spirit resource icon.\nAction: Exhaust Elrond and Vilya to reveal the top card of your deck. You can immediately play or put into play the revealed card for no cost, if able. Otherwise, move the revealed card to the bottom of your deck.",
     "name_norm": "Vilya",
-    "octgn": "51223bd0-ffd1-11df-a976-0801213c9027"
+    "octgn": "51223bd0-ffd1-11df-a976-0801213c9027",
+    "categories": "Resource Smoothing"
   },
   {
     "name": "Beregond",
@@ -4125,7 +4192,8 @@
     "flavor": "`It is over-late to send for aid when you are already besieged.` -The Return of the King",
     "textc": "Sentinel.\nLower the cost to play Weapon and Armor attachments on Beregond by 2.",
     "name_norm": "Beregond",
-    "octgn": "4823aae3-46ef-4a75-89f9-cbd3aa1b9005"
+    "octgn": "4823aae3-46ef-4a75-89f9-cbd3aa1b9005",
+    "categories": ""
   },
   {
     "name": "Boromir",
@@ -4147,7 +4215,8 @@
     "flavor": "`By our valour the wild fold of the East are still restrained, and the terror of Morgul kept at bay...` -The Fellowship of the Ring",
     "textc": "While Boromir has at least 1 resource in his resource pool, Gondor allies get +1 Attack.",
     "name_norm": "Boromir",
-    "octgn": "4823aae3-46ef-4a75-89f9-cbd3aa1b9008"
+    "octgn": "4823aae3-46ef-4a75-89f9-cbd3aa1b9008",
+    "categories": "Attack Bonus"
   },
   {
     "name": "Errand-rider",
@@ -4169,7 +4238,8 @@
     "flavor": "For the people of the City used horses very little and they were seldom seen in their streets, save only those ridden by the errand-riders of their lord. -The Return of the King",
     "textc": "Action: Exhaust Errand-rider to move 1 resource from the resource pool of a hero you control to another hero's resource pool.",
     "name_norm": "Errand-rider",
-    "octgn": "4823aae3-46ef-4a75-89f9-cbd3aa1b9016"
+    "octgn": "4823aae3-46ef-4a75-89f9-cbd3aa1b9016",
+    "categories": "Resource Smoothing"
   },
   {
     "name": "Citadel Custodian",
@@ -4188,10 +4258,10 @@
     "traits": " Gondor.",
     "keywords": "",
     "text": "Lower the cost to play Citadel Custodian by 1 for each Gondor ally in play.",
-    "flavor": null,
     "textc": "Lower the cost to play Citadel Custodian by 1 for each Gondor ally in play.",
     "name_norm": "Citadel Custodian",
-    "octgn": "4823aae3-46ef-4a75-89f9-cbd3aa1b9010"
+    "octgn": "4823aae3-46ef-4a75-89f9-cbd3aa1b9010",
+    "categories": ""
   },
   {
     "name": "Mutual Accord",
@@ -4209,7 +4279,8 @@
     "flavor": "`These are the Rohirrim, as we name them, masters of horses... and have ever proved true to us, aiding us at need, and guarding our northern marches and the Gap of Rohan.` -Faramir, The Two Towers",
     "textc": "Action: Until the end of the phase, each Gondor card in play gains the Rohan trait, and each Rohan card in play gains the Gondor trait.",
     "name_norm": "Mutual Accord",
-    "octgn": "4823aae3-46ef-4a75-89f9-cbd3aa1b9060"
+    "octgn": "4823aae3-46ef-4a75-89f9-cbd3aa1b9060",
+    "categories": ""
   },
   {
     "name": "Wealth of Gondor",
@@ -4227,7 +4298,8 @@
     "flavor": "Kings made tombs more splendid than houses of the living, and counted old names in the rolls of their descent dearer than the names of sons. -The Two Towers",
     "textc": "Action: Choose a Gondor hero. Add 1 resource to that hero's resource pool.",
     "name_norm": "Wealth of Gondor",
-    "octgn": "4823aae3-46ef-4a75-89f9-cbd3aa1b9087"
+    "octgn": "4823aae3-46ef-4a75-89f9-cbd3aa1b9087",
+    "categories": "Resource Acceleration"
   },
   {
     "name": "Defender of Rammas",
@@ -4249,7 +4321,8 @@
     "flavor": "`And the Enemy must pay dearly for the crossing of the River.` -Denethor, The Return of the King",
     "textc": "",
     "name_norm": "Defender of Rammas",
-    "octgn": "4823aae3-46ef-4a75-89f9-cbd3aa1b9014"
+    "octgn": "4823aae3-46ef-4a75-89f9-cbd3aa1b9014",
+    "categories": ""
   },
   {
     "name": "Behind Strong Walls",
@@ -4267,7 +4340,8 @@
     "flavor": "...seven walls of stone so strong and old that it seemed to have been not builded by carven by giants out of the bones of the earth. -The Return of the King",
     "textc": "Action: Ready a defending Gondor character. That character gets +1 Defense until the end of the phase.",
     "name_norm": "Behind Strong Walls",
-    "octgn": "4823aae3-46ef-4a75-89f9-cbd3aa1b9004"
+    "octgn": "4823aae3-46ef-4a75-89f9-cbd3aa1b9004",
+    "categories": "Readying, Defense Bonus"
   },
   {
     "name": "Spear of the Citadel",
@@ -4282,10 +4356,10 @@
     "traits": " Item. Weapon.",
     "keywords": "Restricted.",
     "text": "Attach to a Tactics character. Limit 1 per character.\nResponse: After attached character is declared as a defender, deal 1 damage to the attacking enemy.",
-    "flavor": null,
     "textc": "Restricted.\nAttach to a Tactics character. Limit 1 per character.\nResponse: After attached character is declared as a defender, deal 1 damage to the attacking enemy.",
     "name_norm": "Spear of the Citadel",
-    "octgn": "4823aae3-46ef-4a75-89f9-cbd3aa1b9078"
+    "octgn": "4823aae3-46ef-4a75-89f9-cbd3aa1b9078",
+    "categories": "Direct Damage"
   },
   {
     "name": "Damrod",
@@ -4304,10 +4378,10 @@
     "traits": " Gondor. Ranger.",
     "keywords": "",
     "text": "Action: Discard Damrod from play to lower your threat by 1 for each enemy in the staging area.",
-    "flavor": null,
     "textc": "Action: Discard Damrod from play to lower your threat by 1 for each enemy in the staging area.",
     "name_norm": "Damrod",
-    "octgn": "4823aae3-46ef-4a75-89f9-cbd3aa1b9013"
+    "octgn": "4823aae3-46ef-4a75-89f9-cbd3aa1b9013",
+    "categories": "Threat Control"
   },
   {
     "name": "Light the Beacons",
@@ -4325,7 +4399,8 @@
     "flavor": "`The beacons of Gondor are alight, calling for aid.` -Gandalf, The Return of the King",
     "textc": "Action: All characters get +2 Defense and do not exhaust to defend until the end of the round.",
     "name_norm": "Light the Beacons",
-    "octgn": "4823aae3-46ef-4a75-89f9-cbd3aa1b9050"
+    "octgn": "4823aae3-46ef-4a75-89f9-cbd3aa1b9050",
+    "categories": "Defense Bonus"
   },
   {
     "name": "A Watchful Peace",
@@ -4340,13 +4415,13 @@
     "traits": "",
     "keywords": "",
     "text": "Response: After a location leaves play as an explored location, return it to the top of the encounter deck.",
-    "flavor": null,
     "textc": "Response: After a location leaves play as an explored location, return it to the top of the encounter deck.",
     "name_norm": "A Watchful Peace",
-    "octgn": "4823aae3-46ef-4a75-89f9-cbd3aa1b9002"
+    "octgn": "4823aae3-46ef-4a75-89f9-cbd3aa1b9002",
+    "categories": ""
   },
   {
-    "name": "Blood of Númenor",
+    "name": "Blood of N\u00famenor",
     "type": "3attachment",
     "sphere": "3spirit",
     "cost": 0,
@@ -4357,11 +4432,12 @@
     "unique": false,
     "traits": " Condition.",
     "keywords": "",
-    "text": "Attach to a Gondor or Dúnedain hero.\nAction: Spend 1 resource from attached hero's resource pool to give attached hero +1 Defense for each resource in its resource pool until the end of the phase. (Limit once per phase.)",
+    "text": "Attach to a Gondor or D\u00fanedain hero.\nAction: Spend 1 resource from attached hero's resource pool to give attached hero +1 Defense for each resource in its resource pool until the end of the phase. (Limit once per phase.)",
     "flavor": "`Believe not that in the land of Gondor the blood of Numenor is spent, nor all its pride and dignity forgotten.` -Boromir, The Fellowship of the Ring",
-    "textc": "Attach to a Gondor or Dúnedain hero.\nAction: Spend 1 resource from attached hero's resource pool to give attached hero +1 Defense for each resource in its resource pool until the end of the phase. (Limit once per phase.)",
+    "textc": "Attach to a Gondor or D\u00fanedain hero.\nAction: Spend 1 resource from attached hero's resource pool to give attached hero +1 Defense for each resource in its resource pool until the end of the phase. (Limit once per phase.)",
     "name_norm": "Blood of Numenor",
-    "octgn": "4823aae3-46ef-4a75-89f9-cbd3aa1b9007"
+    "octgn": "4823aae3-46ef-4a75-89f9-cbd3aa1b9007",
+    "categories": "Defense Bonus"
   },
   {
     "name": "Hunter of Lamedon",
@@ -4383,7 +4459,8 @@
     "flavor": "From Lamedon, a few grim hillmen without a captain. -The Return of the King",
     "textc": "Response: After you play Hunter of Lamedon from your hand, reveal the top card of your deck. If it is an Outlands card, add it to your hand. Otherwise, discard it.",
     "name_norm": "Hunter of Lamedon",
-    "octgn": "4823aae3-46ef-4a75-89f9-cbd3aa1b9045"
+    "octgn": "4823aae3-46ef-4a75-89f9-cbd3aa1b9045",
+    "categories": ""
   },
   {
     "name": "Ithilien Tracker",
@@ -4405,7 +4482,8 @@
     "flavor": "Green gauntlets covered their hands, and their faces were hooded and masked with green, except for their eyes, which were very keen and bright. -The Two Towers",
     "textc": "Action: Exhaust Ithilien Tracker to lower the Threat of the next enemy added to the staging area to 0 until the end of the phase.",
     "name_norm": "Ithilien Tracker",
-    "octgn": "4823aae3-46ef-4a75-89f9-cbd3aa1b9048"
+    "octgn": "4823aae3-46ef-4a75-89f9-cbd3aa1b9048",
+    "categories": ""
   },
   {
     "name": "Master of Lore",
@@ -4427,7 +4505,8 @@
     "flavor": "`If Cirith Ungol is named, old men and masters of lore will blanch and fall silent.` -Faramir, The Two Towers",
     "textc": "Action: Exhaust Master of Lore to name a card type. Lower the cost for you to play the next Lore card of that type by 1 until the end of the phase (to a minimum of 1).",
     "name_norm": "Master of Lore",
-    "octgn": "4823aae3-46ef-4a75-89f9-cbd3aa1b9057"
+    "octgn": "4823aae3-46ef-4a75-89f9-cbd3aa1b9057",
+    "categories": ""
   },
   {
     "name": "Ranger Spikes",
@@ -4442,10 +4521,10 @@
     "traits": " Trap.",
     "keywords": "",
     "text": "Play Ranger Spikes into the staging area unattached.\nIf unattached, attach Ranger Spikes to the next eligible enemy that enters the staging area.Players do not make engagement checks against attached enemy. Attached enemy gets -2 Threat.",
-    "flavor": null,
     "textc": "Play Ranger Spikes into the staging area unattached.\nIf unattached, attach Ranger Spikes to the next eligible enemy that enters the staging area.Players do not make engagement checks against attached enemy. Attached enemy gets -2 Threat.",
     "name_norm": "Ranger Spikes",
-    "octgn": "4823aae3-46ef-4a75-89f9-cbd3aa1b9071"
+    "octgn": "4823aae3-46ef-4a75-89f9-cbd3aa1b9071",
+    "categories": ""
   },
   {
     "name": "Envoy of Pelargir",
@@ -4464,10 +4543,10 @@
     "traits": " Gondor.",
     "keywords": "",
     "text": "Response: After Envoy of Pelargir enters play, add 1 resource to a Gondor or Noble hero's resource pool.",
-    "flavor": null,
     "textc": "Response: After Envoy of Pelargir enters play, add 1 resource to a Gondor or Noble hero's resource pool.",
     "name_norm": "Envoy of Pelargir",
-    "octgn": "4823aae3-46ef-4a75-89f9-cbd3aa1b9015"
+    "octgn": "4823aae3-46ef-4a75-89f9-cbd3aa1b9015",
+    "categories": "Resource Smoothing"
   },
   {
     "name": "Hirluin the Fair",
@@ -4489,7 +4568,8 @@
     "flavor": "Hirluin the Fair of the Green Hills from Pinnath Gelin... -The Return of the King",
     "textc": "Ranged.\nYou may use resources from Hirluin the Fair's resource pool to pay for Outlands ally cards of any sphere.",
     "name_norm": "Hirluin the Fair",
-    "octgn": "85699571-9cc3-4ccc-98b0-0e1664893ef5"
+    "octgn": "85699571-9cc3-4ccc-98b0-0e1664893ef5",
+    "categories": ""
   },
   {
     "name": "Warrior of Lossarnach",
@@ -4511,7 +4591,8 @@
     "flavor": "... grim-faced they were, and shorter and somewhat swarthier than any men that Pippin had yet seen in Gondor. - The Return of the King",
     "textc": "Each Outlands character you control gets +1 Defense.",
     "name_norm": "Warrior of Lossarnach",
-    "octgn": "2e84d805-365c-47ea-9c4f-e3f75daeb9a6"
+    "octgn": "2e84d805-365c-47ea-9c4f-e3f75daeb9a6",
+    "categories": "Defense Bonus"
   },
   {
     "name": "Gaining Strength",
@@ -4529,7 +4610,8 @@
     "flavor": "`Nay, my friends, I am the lawful master of the Stone, and I had both the right and the strength to use it...` -Aragorn, The Return of the King",
     "textc": "Action: Discard 2 resources from your hero's resource pool to add 3 resources to that hero's resource pool.",
     "name_norm": "Gaining Strength",
-    "octgn": "add42229-f5d1-4c39-a5dd-ec00ad7d0d76"
+    "octgn": "add42229-f5d1-4c39-a5dd-ec00ad7d0d76",
+    "categories": "Resource Acceleration"
   },
   {
     "name": "Knights of the Swan",
@@ -4551,7 +4633,8 @@
     "flavor": "...foremost on the field rode the swan-knights of Dol Amroth with their Prince and his blue banner at their head. -The Return of the King",
     "textc": "Each Outlands character you control gets +1 Attack.",
     "name_norm": "Knights of the Swan",
-    "octgn": "c00844d6-1c3c-4e8c-a46c-8de15b8408df"
+    "octgn": "c00844d6-1c3c-4e8c-a46c-8de15b8408df",
+    "categories": "Attack Bonus"
   },
   {
     "name": "Gondorian Shield",
@@ -4569,7 +4652,8 @@
     "flavor": "There flowered a White Tree, and that was for Gondor... -The Return of the King",
     "textc": "Restricted.\nAttach to a hero. Limit 1 per hero.\nAttached hero gains +1 Defense. (+2 Defense instead if attached hero has the Gondor trait.)",
     "name_norm": "Gondorian Shield",
-    "octgn": "09134509-191b-4903-b4b5-5e650f8143c1"
+    "octgn": "09134509-191b-4903-b4b5-5e650f8143c1",
+    "categories": "Defense Bonus"
   },
   {
     "name": "Ethir Swordsman",
@@ -4588,10 +4672,10 @@
     "traits": " Outlands.",
     "keywords": "",
     "text": "Each Outlands character you control gets +1 Willpower.",
-    "flavor": null,
     "textc": "Each Outlands character you control gets +1 Willpower.",
     "name_norm": "Ethir Swordsman",
-    "octgn": "1c149f93-9e3b-42fa-878c-80b29563a283"
+    "octgn": "1c149f93-9e3b-42fa-878c-80b29563a283",
+    "categories": ""
   },
   {
     "name": "Ring of Barahir",
@@ -4606,10 +4690,10 @@
     "traits": " Artifact. Item. Ring.",
     "keywords": "",
     "text": "Attach to a hero.\nAttached hero gets +1 hit point for each Artifact attachment attached to it.\nIf attached hero is Aragorn, he also gains a Lore resource icon.",
-    "flavor": null,
     "textc": "Attach to a hero.\nAttached hero gets +1 hit point for each Artifact attachment attached to it.\nIf attached hero is Aragorn, he also gains a Lore resource icon.",
     "name_norm": "Ring of Barahir",
-    "octgn": "0ef9e385-b7e5-4676-a690-2dd8031aa8c8"
+    "octgn": "0ef9e385-b7e5-4676-a690-2dd8031aa8c8",
+    "categories": "Hit Point Bonus, Resource Smoothing"
   },
   {
     "name": "Anfalas Herdsman",
@@ -4631,7 +4715,8 @@
     "flavor": "From the Anfalas, the Langstrand far away, a long line of men of many sorts, hunters and herdsmen and men of little villages... -The Return of the King",
     "textc": "Each Outlands character you control gets +1 hit point.",
     "name_norm": "Anfalas Herdsman",
-    "octgn": "4cb4741d-c9d8-4d62-ab4f-50fa80c59fbb"
+    "octgn": "4cb4741d-c9d8-4d62-ab4f-50fa80c59fbb",
+    "categories": "Hit Point Bonus"
   },
   {
     "name": "Mithrandir's Advice",
@@ -4649,7 +4734,8 @@
     "flavor": "`Let none now reject the counsels of Gandalf, whose long labours against Sauron come at last to their test.` -Aragorn, The Return of the King",
     "textc": "Action: Draw 1 card for each hero you control with a printed Lore resource icon.",
     "name_norm": "Mithrandir's Advice",
-    "octgn": "3c47d373-62bc-4321-9dc1-9b86b2046f68"
+    "octgn": "3c47d373-62bc-4321-9dc1-9b86b2046f68",
+    "categories": "Card Draw"
   },
   {
     "name": "A Good Harvest",
@@ -4667,7 +4753,8 @@
     "flavor": "The townlands were rich, with wide tilth and many orchards, and homesteads there were with oast and garner, fold and byre, and many rills rippling through the green from the highlands down to the Anduin. -The Return of the King",
     "textc": "Action: Name a sphere. Until the end of the phase, you can spend resources of any sphere when paying for cards that belong to the named sphere.",
     "name_norm": "A Good Harvest",
-    "octgn": "e02f317e-736c-40a0-8d73-45509fce9ef8"
+    "octgn": "e02f317e-736c-40a0-8d73-45509fce9ef8",
+    "categories": "Resource Smoothing"
   },
   {
     "name": "Mirlonde",
@@ -4686,10 +4773,10 @@
     "traits": " Silvan.",
     "keywords": "",
     "text": "Each hero you control with a printed Lore resource icon gets -1 threat cost.",
-    "flavor": null,
     "textc": "Each hero you control with a printed Lore resource icon gets -1 threat cost.",
     "name_norm": "Mirlonde",
-    "octgn": "536c80ba-ad8b-447e-b378-1684508eb0f9"
+    "octgn": "536c80ba-ad8b-447e-b378-1684508eb0f9",
+    "categories": ""
   },
   {
     "name": "Forlong",
@@ -4711,7 +4798,8 @@
     "flavor": "`Forlong!` men shouted. `True heart, true friend!` -The Return of the King",
     "textc": "While you control Outlands allies that belong to 4 different spheres, ready Forlong at the beginning of each phase.",
     "name_norm": "Forlong",
-    "octgn": "c6ae1840-dd7d-46ea-baf8-6d30614506de"
+    "octgn": "c6ae1840-dd7d-46ea-baf8-6d30614506de",
+    "categories": ""
   },
   {
     "name": "Strength of Arms",
@@ -4729,7 +4817,8 @@
     "flavor": "And so the companies came and were hailed and cheered and passed through the Gate, men of the Outlands marching to defend the City of Gondor in a dark hour... -The Return of the King",
     "textc": "Play only if each hero you control has a printed Leadership resource icon.\nAction: Ready each ally in play.",
     "name_norm": "Strength of Arms",
-    "octgn": "91f28bdf-4b78-4750-9853-65e783e4cb15"
+    "octgn": "91f28bdf-4b78-4750-9853-65e783e4cb15",
+    "categories": "Readying"
   },
   {
     "name": "Mighty Prowess",
@@ -4747,7 +4836,8 @@
     "flavor": "He slew many of them and the rest fled. -The Two Towers",
     "textc": "Attach to a Tactics hero. Limit 1 per hero.\nResponse: After attached hero attacks and destroys an enemy, deal 1 damage to another enemy that shares a Trait with the enemy just destroyed.",
     "name_norm": "Mighty Prowess",
-    "octgn": "4ed8bd53-0453-4490-a4bb-20a7d793c17f"
+    "octgn": "4ed8bd53-0453-4490-a4bb-20a7d793c17f",
+    "categories": "Direct Damage"
   },
   {
     "name": "Trained for War",
@@ -4762,10 +4852,10 @@
     "traits": "",
     "keywords": "",
     "text": "Play only if each hero you control has the printed Tactics resource icon.\nAction: Until the end of the phase, if the current quest has no keyword it gains Battle.",
-    "flavor": null,
     "textc": "Play only if each hero you control has the printed Tactics resource icon.\nAction: Until the end of the phase, if the current quest has no keyword it gains Battle.",
     "name_norm": "Trained for War",
-    "octgn": "5c7a6b89-0439-4b46-b9f1-09189f981a0d"
+    "octgn": "5c7a6b89-0439-4b46-b9f1-09189f981a0d",
+    "categories": ""
   },
   {
     "name": "Silvan Refugee",
@@ -4787,7 +4877,8 @@
     "flavor": "`The Elves have their own labours and their own sorrows...` -Gildor, The Fellowship of the Ring",
     "textc": "Forced: After a character leaves play, discard Silvan Refugee from play.",
     "name_norm": "Silvan Refugee",
-    "octgn": "e4fd6e25-982a-464f-82d8-812269864d46"
+    "octgn": "e4fd6e25-982a-464f-82d8-812269864d46",
+    "categories": ""
   },
   {
     "name": "Against the Shadow",
@@ -4805,7 +4896,8 @@
     "flavor": "`Courage will now be your best defense against the storm that is at hand...` -Gandalf, The Return of the King",
     "textc": "Play only if each hero you control has the printed Spirit resource icon.\nAction: Until the end of the phase, Spirit characters use their Willpower instead of Defense.",
     "name_norm": "Against the Shadow",
-    "octgn": "0801c2c0-2bf7-4a0a-838a-13740f6cdbaf"
+    "octgn": "0801c2c0-2bf7-4a0a-838a-13740f6cdbaf",
+    "categories": ""
   },
   {
     "name": "Harbor Master",
@@ -4827,7 +4919,8 @@
     "flavor": "For the Elves of the High Kindred had not yet forsaken Middle-earth, and they dwelt still at that time at the Grey Havens...-The Fellowship of the Ring",
     "textc": "Response: After a card effect adds any number of resources to the resource pool of a hero you control, Harbor Master gains +1 Defense until the end of the round.",
     "name_norm": "Harbor Mastery",
-    "octgn": "b7f8b82b-c448-4f43-a025-bf6b7e6f0310"
+    "octgn": "b7f8b82b-c448-4f43-a025-bf6b7e6f0310",
+    "categories": "Defense Bonus"
   },
   {
     "name": "Advance Warning",
@@ -4845,7 +4938,8 @@
     "flavor": "Suddenly he halted and listened. Had he heard a whistle or not? Or was it the call of some strange bird? -The Two Towers",
     "textc": "Play only if each hero you control has a printed Lore resource icon.\nAction: Until the end of the phase, enemies do not make engagement checks",
     "name_norm": "Advance Warning",
-    "octgn": "e678be7e-8048-458d-b4f9-25c2a718fabb"
+    "octgn": "e678be7e-8048-458d-b4f9-25c2a718fabb",
+    "categories": ""
   },
   {
     "name": "White Tower Watchman",
@@ -4867,7 +4961,8 @@
     "flavor": "The watchmen cried aloud, and all men in the City stood to arms. -The Return of the King",
     "textc": "If each hero you control belongs to the same sphere of influence, you may assign damage from undefended enemy attacks to White Tower Watchman instead of a hero you control.",
     "name_norm": "White Tower Watchman",
-    "octgn": "31cd848b-a1bc-4ccd-af0c-eb3cc3ba593b"
+    "octgn": "31cd848b-a1bc-4ccd-af0c-eb3cc3ba593b",
+    "categories": ""
   },
   {
     "name": "Pippin",
@@ -4889,7 +4984,8 @@
     "flavor": "`There must be someone with intelligence in the party.` -The Fellowship of the Ring",
     "textc": "If each hero you control has the Hobbit trait, Pippin gains: 'Response: After an enemy engages you, raise your threat by 3 to return it to the staging area. Until the end of the round, that enemy cannot engage you.'",
     "name_norm": "Pippin",
-    "octgn": "fd89bdbf-7475-4f3e-96fc-8f5315a90021"
+    "octgn": "fd89bdbf-7475-4f3e-96fc-8f5315a90021",
+    "categories": ""
   },
   {
     "name": "Denethor",
@@ -4911,7 +5007,8 @@
     "flavor": "`Denethor is of another sort, proud and subtile, a man of far greater lineage and power, though he is not called a king.` -Gandalf, The Return of the King",
     "textc": "Denethor gets -1 Willpower for each damaged hero you control.\nDiscard Denethor if his Willpower is 0 or less.",
     "name_norm": "Denethor",
-    "octgn": "fd89bdbf-7475-4f3e-96fc-8f5315a90022"
+    "octgn": "fd89bdbf-7475-4f3e-96fc-8f5315a90022",
+    "categories": ""
   },
   {
     "name": "Lord of Morthond",
@@ -4929,7 +5026,8 @@
     "flavor": "`The Captains of the Outlands are expected up the South Road ere sundown. Come with us and you will see.` -Bergil, The Return of the King",
     "textc": "Attach to a Gondor or Outlands hero.\nIf each hero you control has a printed Leadership resource icon, Lord of Morthond gains: 'Response: After you play a Lore, Spirit, or Tactics ally, draw 1 card.'",
     "name_norm": "Lord of Morthond",
-    "octgn": "fd89bdbf-7475-4f3e-96fc-8f5315a90023"
+    "octgn": "fd89bdbf-7475-4f3e-96fc-8f5315a90023",
+    "categories": "Card Draw"
   },
   {
     "name": "Book of Eldacar",
@@ -4944,10 +5042,10 @@
     "traits": " Record.",
     "keywords": "",
     "text": "Attach to a Tactics hero.\nReduce the cost to play Book of Eldacar by 1 for each hero you control with a printed Tactics resource icon.\nAction: Discard Book of Eldacar to play any Tactics event card in your discard pile as if it were in your hand. Then, place that event on the bottom of your deck.",
-    "flavor": null,
     "textc": "Attach to a Tactics hero.\nReduce the cost to play Book of Eldacar by 1 for each hero you control with a printed Tactics resource icon.\nAction: Discard Book of Eldacar to play any Tactics event card in your discard pile as if it were in your hand. Then, place that event on the bottom of your deck.",
     "name_norm": "Book of Eldacar",
-    "octgn": "fd89bdbf-7475-4f3e-96fc-8f5315a90024"
+    "octgn": "fd89bdbf-7475-4f3e-96fc-8f5315a90024",
+    "categories": ""
   },
   {
     "name": "Gondorian Discipline",
@@ -4965,7 +5063,8 @@
     "flavor": "At last, less than a mile from the City, a more ordered mass of men came into view, marching not running, still holding together. -The Return of the King",
     "textc": "Response: Cancel up to 2 points of damage just dealt to a Gondor character.",
     "name_norm": "Gondorian Discipline",
-    "octgn": "fd89bdbf-7475-4f3e-96fc-8f5315a90025"
+    "octgn": "fd89bdbf-7475-4f3e-96fc-8f5315a90025",
+    "categories": ""
   },
   {
     "name": "Minas Tirith Lampwright",
@@ -4984,10 +5083,10 @@
     "traits": " Gondor. Craftsman.",
     "keywords": "",
     "text": "Response: After an encounter card with surge is revealed, discard Minas Tirith Lampwright to name enemy, location, or treachery. If the next encounter card revealed is the named type, discard it without resolving its effects.",
-    "flavor": null,
     "textc": "Response: After an encounter card with surge is revealed, discard Minas Tirith Lampwright to name enemy, location, or treachery. If the next encounter card revealed is the named type, discard it without resolving its effects.",
     "name_norm": "Minas Tirith Lampwright",
-    "octgn": "fd89bdbf-7475-4f3e-96fc-8f5315a90026"
+    "octgn": "fd89bdbf-7475-4f3e-96fc-8f5315a90026",
+    "categories": ""
   },
   {
     "name": "Small Target",
@@ -5002,10 +5101,10 @@
     "traits": "",
     "keywords": "",
     "text": "Response: After a Hobbit hero you control exhausts to defend an attack, choose another enemy engaged with you and reveal the attacking enemy's shadow card. If that shadow card has no shadow effect, resolve this enemy's attack against the chosen enemy. If that shadow card has a shadow effect, resolve this attack as normal.",
-    "flavor": null,
     "textc": "Response: After a Hobbit hero you control exhausts to defend an attack, choose another enemy engaged with you and reveal the attacking enemy's shadow card. If that shadow card has no shadow effect, resolve this enemy's attack against the chosen enemy. If that shadow card has a shadow effect, resolve this attack as normal.",
     "name_norm": "Small Target",
-    "octgn": "fd89bdbf-7475-4f3e-96fc-8f5315a90027"
+    "octgn": "fd89bdbf-7475-4f3e-96fc-8f5315a90027",
+    "categories": ""
   },
   {
     "name": "Ithilien Archer",
@@ -5024,10 +5123,10 @@
     "traits": " Gondor. Ranger.",
     "keywords": "Ranged.",
     "text": "Response: After Ithilien Archer attacks and damages an enemy, return that enemy to the staging area.",
-    "flavor": null,
     "textc": "Ranged.\nResponse: After Ithilien Archer attacks and damages an enemy, return that enemy to the staging area.",
     "name_norm": "Ithilien Archer",
-    "octgn": "fd89bdbf-7475-4f3e-96fc-8f5315a90028"
+    "octgn": "fd89bdbf-7475-4f3e-96fc-8f5315a90028",
+    "categories": ""
   },
   {
     "name": "Ithilien Pit",
@@ -5042,10 +5141,10 @@
     "traits": " Trap.",
     "keywords": "",
     "text": "Play Ithilien Pit into the staging area unattached.\n\nIf unattached, attach Ithilien Pit to the next eligible enemy that enters the staging area.\n\nAny character may choose attached enemy as the target of an attack.",
-    "flavor": null,
     "textc": "Play Ithilien Pit into the staging area unattached.\n\nIf unattached, attach Ithilien Pit to the next eligible enemy that enters the staging area.\n\nAny character may choose attached enemy as the target of an attack.",
     "name_norm": "Ithilien Pit",
-    "octgn": "fd89bdbf-7475-4f3e-96fc-8f5315a90029"
+    "octgn": "fd89bdbf-7475-4f3e-96fc-8f5315a90029",
+    "categories": ""
   },
   {
     "name": "Hobbit-sense",
@@ -5063,7 +5162,8 @@
     "flavor": "They possessed from the first the art of disappearing swiftly and silently, when large folk whom they do not wish to meet come blundering by... -The Fellowship of the Ring",
     "textc": "Play only if each of your heroes is a Hobbit. Combat Action: Enemies engaged with you do not attack this round. You cannot declare attacks this round.",
     "name_norm": "Hobbit-sense",
-    "octgn": "fd89bdbf-7475-4f3e-96fc-8f5315a90030"
+    "octgn": "fd89bdbf-7475-4f3e-96fc-8f5315a90030",
+    "categories": "Combat Control"
   },
   {
     "name": "Faramir",
@@ -5085,7 +5185,8 @@
     "flavor": "`The road may pass, but they shall not! Not while Faramir is Captain.` -Mablung, The Two Towers",
     "textc": "Ranged.\nFaramir gets +1 Attack for each enemy in the staging area.",
     "name_norm": "Faramir",
-    "octgn": "323ebfa3-57e5-4394-9f55-284b2f7ee0be"
+    "octgn": "323ebfa3-57e5-4394-9f55-284b2f7ee0be",
+    "categories": "Attack Bonus"
   },
   {
     "name": "Sword of Morthond",
@@ -5100,16 +5201,17 @@
     "traits": " Item. Weapon.",
     "keywords": "",
     "text": "Attach to a Gondor ally.\nAttached ally gains the Outlands trait.",
-    "flavor": "The Morthond Valye made a great bay that beat up against the sheer southern faces of the mountains.\r\n-The Return of the King",
+    "flavor": "The Morthond Valye made a great bay that beat up against the sheer southern faces of the mountains.\n-The Return of the King",
     "textc": "Attach to a Gondor ally.\nAttached ally gains the Outlands trait.",
     "name_norm": "Sword of Morthond",
-    "octgn": "98ba9e54-d6c3-41ff-b886-81a29e29eb64"
+    "octgn": "98ba9e54-d6c3-41ff-b886-81a29e29eb64",
+    "categories": ""
   },
   {
     "name": "Men of the West",
     "type": "4event",
     "sphere": "1leadership",
-    "cost": "X",
+    "cost": 0,
     "cycle": 5,
     "exp": "aoo",
     "no": 83,
@@ -5118,10 +5220,11 @@
     "traits": " Outlands.",
     "keywords": "",
     "text": "Action: Return X Outlands allies from your discard pile to your hand.",
-    "flavor": "Death in the morning and at day's ending\r\nlords took and lowly. Long now they sleep\r\nunder grass in Gondor by the Great River.\r\n-The Return of the King ",
+    "flavor": "Death in the morning and at day's ending\nlords took and lowly. Long now they sleep\nunder grass in Gondor by the Great River.\n-The Return of the King ",
     "textc": "Action: Return X Outlands allies from your discard pile to your hand.",
     "name_norm": "Men of the West",
-    "octgn": "a2d440c4-6150-4b6f-9a36-faa51ace7908"
+    "octgn": "a2d440c4-6150-4b6f-9a36-faa51ace7908",
+    "categories": ""
   },
   {
     "name": "Knight of Minas Tirith",
@@ -5140,10 +5243,10 @@
     "traits": " Gondor. Warrior.",
     "keywords": "",
     "text": "If each of your heroes has a printed Tactics resource icon, Knight of Minas Tirith gains: `Response: After Knight of Minas Tirith enters play, choose an enemy in the staging area. Engage that enemy and exhaust Knight of Minas Tirith to declare it as attacker (and resolve its attack) against that enemy.`",
-    "flavor": null,
     "textc": "If each of your heroes has a printed Tactics resource icon, Knight of Minas Tirith gains: `Response: After Knight of Minas Tirith enters play, choose an enemy in the staging area. Engage that enemy and exhaust Knight of Minas Tirith to declare it as attacker (and resolve its attack) against that enemy.`",
     "name_norm": "Knight of Minas Tirith",
-    "octgn": "237b31e7-d0b0-4c1e-bd4a-40a175f7d7d1"
+    "octgn": "237b31e7-d0b0-4c1e-bd4a-40a175f7d7d1",
+    "categories": ""
   },
   {
     "name": "Gondorian Fire",
@@ -5157,11 +5260,11 @@
     "unique": false,
     "traits": " Gondor.",
     "keywords": "",
-    "text": "Attach to a Gondor or Dúnedain hero.\nAction: Spend 1 resource from attached hero's resource pool to give attached hero +1 Attack for each resource in its resource pool until the end of the phase. (Limit once per phase.)",
-    "flavor": null,
-    "textc": "Attach to a Gondor or Dúnedain hero.\nAction: Spend 1 resource from attached hero's resource pool to give attached hero +1 Attack for each resource in its resource pool until the end of the phase. (Limit once per phase.)",
+    "text": "Attach to a Gondor or D\u00fanedain hero.\nAction: Spend 1 resource from attached hero's resource pool to give attached hero +1 Attack for each resource in its resource pool until the end of the phase. (Limit once per phase.)",
+    "textc": "Attach to a Gondor or D\u00fanedain hero.\nAction: Spend 1 resource from attached hero's resource pool to give attached hero +1 Attack for each resource in its resource pool until the end of the phase. (Limit once per phase.)",
     "name_norm": "Gondorian Fire",
-    "octgn": "a7f12d87-5f28-46ca-a301-0ac48ca5e471"
+    "octgn": "a7f12d87-5f28-46ca-a301-0ac48ca5e471",
+    "categories": "Attack Bonus"
   },
   {
     "name": "Pelargir Shipwright",
@@ -5180,10 +5283,11 @@
     "traits": " Gondor. Craftsman.",
     "keywords": "",
     "text": "Pelargir Shipwright gets +1 Willpower for each hero you control with a printed Spirit resource icon.",
-    "flavor": "`It is forty leagues and two from Pelargir to the landings at the Harlond...`\r\n-Aragorn, The Return of the King",
+    "flavor": "`It is forty leagues and two from Pelargir to the landings at the Harlond...`\n-Aragorn, The Return of the King",
     "textc": "Pelargir Shipwright gets +1 Willpower for each hero you control with a printed Spirit resource icon.",
     "name_norm": "Pelargir Shipwright",
-    "octgn": "d8d1e7b4-3639-4ca0-bc83-daa7f78554b2"
+    "octgn": "d8d1e7b4-3639-4ca0-bc83-daa7f78554b2",
+    "categories": ""
   },
   {
     "name": "Map of Earnil",
@@ -5198,10 +5302,10 @@
     "traits": " Record.",
     "keywords": "",
     "text": "Attach to a Spirit hero.\nReduce the cost to play Map of Earnil by 1 for each hero you control with a printed Spirit resource icon.\nAction: Discard Map of Earnil to play any Spirit event card in your discard pile as if it were in your hand. Then, place that event on the bottom of your deck.",
-    "flavor": null,
     "textc": "Attach to a Spirit hero.\nReduce the cost to play Map of Earnil by 1 for each hero you control with a printed Spirit resource icon.\nAction: Discard Map of Earnil to play any Spirit event card in your discard pile as if it were in your hand. Then, place that event on the bottom of your deck.",
     "name_norm": "Map of Earnil",
-    "octgn": "72cb5c31-c62f-4870-a5f4-099cdec1d4a7"
+    "octgn": "72cb5c31-c62f-4870-a5f4-099cdec1d4a7",
+    "categories": ""
   },
   {
     "name": "Ranger Bow",
@@ -5216,10 +5320,11 @@
     "traits": " Weapon.",
     "keywords": "Restricted.",
     "text": "Attach to a Ranger character.\nAction: Exhaust Ranger Bow and attached character to deal 1 damage to an enemy in the staging area.",
-    "flavor": "Two had great bows, almost of their own height, and great quivers of long green-feathered arrows.\r\n-The Two Towers",
+    "flavor": "Two had great bows, almost of their own height, and great quivers of long green-feathered arrows.\n-The Two Towers",
     "textc": "Restricted.\nAttach to a Ranger character.\nAction: Exhaust Ranger Bow and attached character to deal 1 damage to an enemy in the staging area.",
     "name_norm": "Ranger Bow",
-    "octgn": "3fa0b17f-a7d1-4f0c-a779-c20cb6084e78"
+    "octgn": "3fa0b17f-a7d1-4f0c-a779-c20cb6084e78",
+    "categories": "Direct Damage"
   },
   {
     "name": "Forest Patrol",
@@ -5237,7 +5342,8 @@
     "flavor": "`For coming unbidden to this play death is our law.` -Anborn, The Two Towers",
     "textc": "Play only if you control at least 1 Ranger character.\nAction: Deal 3 damage to an enemy with at least 1 Trap card attached to it.",
     "name_norm": "Forest Patrol",
-    "octgn": "50aa4aab-6daa-4cb5-bfb1-a13db03c1a23"
+    "octgn": "50aa4aab-6daa-4cb5-bfb1-a13db03c1a23",
+    "categories": "Direct Damage"
   },
   {
     "name": "Palantir",
@@ -5252,10 +5358,10 @@
     "traits": " Artifact. Item.",
     "keywords": "",
     "text": "Attach to a Noble hero.\nPlanning Action: Exhaust Palantir and attached hero to name a card type and look at the top 3 cards of the encounter deck. For each of those cards that matches the named type, draw a card. For each of those cards that does not match the named type, raise your threat by 2.",
-    "flavor": null,
     "textc": "Attach to a Noble hero.\nPlanning Action: Exhaust Palantir and attached hero to name a card type and look at the top 3 cards of the encounter deck. For each of those cards that matches the named type, draw a card. For each of those cards that does not match the named type, raise your threat by 2.",
     "name_norm": "Palantir",
-    "octgn": "1e9a6c59-8dc7-4dc4-a5a4-f5f4f9ccdc55"
+    "octgn": "1e9a6c59-8dc7-4dc4-a5a4-f5f4f9ccdc55",
+    "categories": "Card Draw"
   },
   {
     "name": "Caldara",
@@ -5274,10 +5380,11 @@
     "traits": " Gondor.",
     "keywords": "",
     "text": "Action: Discard Caldara to put 1 Spirit ally from your discard pile into play for each other hero you control with a printed Spirit resource icon.",
-    "flavor": "...there is no purpose higher in the world as it now stands than the good of Gondor...\r\n-Denethor, The Return of the King",
+    "flavor": "...there is no purpose higher in the world as it now stands than the good of Gondor...\n-Denethor, The Return of the King",
     "textc": "Action: Discard Caldara to put 1 Spirit ally from your discard pile into play for each other hero you control with a printed Spirit resource icon.",
     "name_norm": "Caldara",
-    "octgn": "60725069-031c-4251-9b2c-3f368545e9ac"
+    "octgn": "60725069-031c-4251-9b2c-3f368545e9ac",
+    "categories": ""
   },
   {
     "name": "Squire of the Citadel",
@@ -5296,10 +5403,11 @@
     "traits": " Gondor.",
     "keywords": "",
     "text": "Response: After Squire of the Citadel leaves play, add 1 resource to a Gondor hero's resource pool.",
-    "flavor": "As he spoke he struck a small silver gong that stood near his footstool, and at once servants came forward.\r\n-The Return of the King",
+    "flavor": "As he spoke he struck a small silver gong that stood near his footstool, and at once servants came forward.\n-The Return of the King",
     "textc": "Response: After Squire of the Citadel leaves play, add 1 resource to a Gondor hero's resource pool.",
     "name_norm": "Squire of the Citadel",
-    "octgn": "d4f034b0-2444-4b61-a249-8d86e8856f7c"
+    "octgn": "d4f034b0-2444-4b61-a249-8d86e8856f7c",
+    "categories": "Resource Acceleration"
   },
   {
     "name": "Tome of Atanatar",
@@ -5314,10 +5422,10 @@
     "traits": " Record.",
     "keywords": "",
     "text": "Attach to a Leadership hero. Reduce the cost to play Tome of Atanatar by 1 for each hero you control with a printed Leadership resource icon.\nAction: Discard Tome of Atanatar to play any Leadership event card in your discard pile as if it were in your hand. Then, place that event on the bottom of your deck.",
-    "flavor": null,
     "textc": "Attach to a Leadership hero. Reduce the cost to play Tome of Atanatar by 1 for each hero you control with a printed Leadership resource icon.\nAction: Discard Tome of Atanatar to play any Leadership event card in your discard pile as if it were in your hand. Then, place that event on the bottom of your deck.",
     "name_norm": "Tome of Atanatar",
-    "octgn": "e88d7165-821c-4b04-9869-80ee1f33905c"
+    "octgn": "e88d7165-821c-4b04-9869-80ee1f33905c",
+    "categories": ""
   },
   {
     "name": "Guthlaf",
@@ -5336,10 +5444,10 @@
     "traits": " Rohan.",
     "keywords": "",
     "text": "If there is at least 1 Rohan hero in play, lower the cost to play Guthlaf by 1.\nIf there is at least 1 Gondor hero in play, Guthlaf gains sentinel.",
-    "flavor": null,
     "textc": "If there is at least 1 Rohan hero in play, lower the cost to play Guthlaf by 1.\nIf there is at least 1 Gondor hero in play, Guthlaf gains sentinel.",
     "name_norm": "Guthlaf",
-    "octgn": "06baca74-330a-4038-9387-32ce8657dd8f"
+    "octgn": "06baca74-330a-4038-9387-32ce8657dd8f",
+    "categories": ""
   },
   {
     "name": "The Hammer-stroke",
@@ -5354,10 +5462,11 @@
     "traits": "",
     "keywords": "",
     "text": "Encounter Action: Engage each enemy in play.",
-    "flavor": "..we have this honour: ever we bear the brunt of the chief hatred of the Dark Lord, for that hatred comes down out of the of the depths of time and over the deeps of the Sea.\r\n-Denethor, The Return of the King",
+    "flavor": "..we have this honour: ever we bear the brunt of the chief hatred of the Dark Lord, for that hatred comes down out of the of the depths of time and over the deeps of the Sea.\n-Denethor, The Return of the King",
     "textc": "Encounter Action: Engage each enemy in play.",
     "name_norm": "The Hammer-stroke",
-    "octgn": "cc2f73af-86c8-4d81-b706-14127adc0b37"
+    "octgn": "cc2f73af-86c8-4d81-b706-14127adc0b37",
+    "categories": ""
   },
   {
     "name": "Emery",
@@ -5376,10 +5485,10 @@
     "traits": " Gondor.",
     "keywords": "",
     "text": "Action: Discard the top 3 card of your deck to put Emery into play from your hand, under any player's control. Then, if any of the discarded cards have the Tactics, Lore or Leadership sphere, discard Emery.",
-    "flavor": null,
     "textc": "Action: Discard the top 3 card of your deck to put Emery into play from your hand, under any player's control. Then, if any of the discarded cards have the Tactics, Lore or Leadership sphere, discard Emery.",
     "name_norm": "Emery",
-    "octgn": "314eaf40-1554-4c1a-b643-1f4353e25633"
+    "octgn": "314eaf40-1554-4c1a-b643-1f4353e25633",
+    "categories": ""
   },
   {
     "name": "Children of the Sea",
@@ -5394,10 +5503,11 @@
     "traits": "",
     "keywords": "",
     "text": "Action: Choose a Silvan or Noldor ally you control. That ally gets +2 Willpower until the end of the phase. At the end of the phase, shuffle that ally into its owner's deck if it is still in play.",
-    "flavor": "`For deep in the hears of all my kindred lies the sea-longing, which it is perilous to stir`\r\n-Legolas, The Return of the King",
+    "flavor": "`For deep in the hears of all my kindred lies the sea-longing, which it is perilous to stir`\n-Legolas, The Return of the King",
     "textc": "Action: Choose a Silvan or Noldor ally you control. That ally gets +2 Willpower until the end of the phase. At the end of the phase, shuffle that ally into its owner's deck if it is still in play.",
     "name_norm": "Children of the Sea",
-    "octgn": "65d3b334-df93-43c6-9525-12674bbb7f06"
+    "octgn": "65d3b334-df93-43c6-9525-12674bbb7f06",
+    "categories": ""
   },
   {
     "name": "Anborn",
@@ -5416,10 +5526,11 @@
     "traits": " Gondor. Ranger.",
     "keywords": "",
     "text": "Action: Exhaust Anborn to return 1 Trap card from your discard pile to your hand.",
-    "flavor": "`I sent my keenest huntsmen to seek him, but he slipped them, and they had no sight of him till now, save Anborn.`\r\n-Faramir, The Two Towers",
+    "flavor": "`I sent my keenest huntsmen to seek him, but he slipped them, and they had no sight of him till now, save Anborn.`\n-Faramir, The Two Towers",
     "textc": "Action: Exhaust Anborn to return 1 Trap card from your discard pile to your hand.",
     "name_norm": "Anborn",
-    "octgn": "ef8aec20-e0c9-4d02-9dea-20b6e7c2278b"
+    "octgn": "ef8aec20-e0c9-4d02-9dea-20b6e7c2278b",
+    "categories": ""
   },
   {
     "name": "Poisoned Stakes",
@@ -5434,10 +5545,10 @@
     "traits": " Trap.",
     "keywords": "",
     "text": "Play Poisoned Stakes into the staging area unattached.\nIf unattached, attach Poisoned Stakes to the next eligble enemy that enters the staging area.\nAt the end of each round, deal 2 damage to attached enemy.",
-    "flavor": null,
     "textc": "Play Poisoned Stakes into the staging area unattached.\nIf unattached, attach Poisoned Stakes to the next eligble enemy that enters the staging area.\nAt the end of each round, deal 2 damage to attached enemy.",
     "name_norm": "Poisoned Stakes",
-    "octgn": "30e0c679-3ced-4862-a681-b67ceb8939d3"
+    "octgn": "30e0c679-3ced-4862-a681-b67ceb8939d3",
+    "categories": "Direct Damage"
   },
   {
     "name": "Well-Equipped",
@@ -5452,13 +5563,14 @@
     "traits": "",
     "keywords": "",
     "text": "Action: Discard the top 2 cards of your deck. You may attach 1 attachment card discarded by this effect to an eligible Dwarf character in play.",
-    "flavor": "Gimli the Dwarf alone wore openly a short shirt of steel-rings, for dwarves make light of burdens...\r\n-The Fellowship of the Ring",
+    "flavor": "Gimli the Dwarf alone wore openly a short shirt of steel-rings, for dwarves make light of burdens...\n-The Fellowship of the Ring",
     "textc": "Action: Discard the top 2 cards of your deck. You may attach 1 attachment card discarded by this effect to an eligible Dwarf character in play.",
     "name_norm": "Well-Equipped",
-    "octgn": "0f027b32-f63f-4d37-8305-5ba2b059289d"
+    "octgn": "0f027b32-f63f-4d37-8305-5ba2b059289d",
+    "categories": ""
   },
   {
-    "name": "Théoden",
+    "name": "Th\u00e9oden",
     "type": "1hero",
     "sphere": "2tactics",
     "cost": 12,
@@ -5474,10 +5586,11 @@
     "traits": " Rohan. Noble. Warrior.",
     "keywords": "Sentinel.",
     "text": "Each hero with a printed Tactics resource icon gets +1 Willpower.",
-    "flavor": "'To me! To me!' cried Théoden. 'Up Eorlingas! Fear no darkness!' - The Return of the King",
+    "flavor": "'To me! To me!' cried Th\u00e9oden. 'Up Eorlingas! Fear no darkness!' - The Return of the King",
     "textc": "Sentinel.\nEach hero with a printed Tactics resource icon gets +1 Willpower.",
     "name_norm": "Theoden",
-    "octgn": "29d5feef-6165-4077-bb80-692526a8a924"
+    "octgn": "29d5feef-6165-4077-bb80-692526a8a924",
+    "categories": ""
   },
   {
     "name": "Pelargir Ship Captain",
@@ -5496,10 +5609,10 @@
     "traits": " Gondor.",
     "keywords": "",
     "text": "Response: After Pelargir Ship Captain enters play, move 1 resource from the resource pool of a hero you control to another hero's resource pool.",
-    "flavor": null,
     "textc": "Response: After Pelargir Ship Captain enters play, move 1 resource from the resource pool of a hero you control to another hero's resource pool.",
     "name_norm": "Pelargir Ship Captain",
-    "octgn": "1f28f098-09d4-43fa-8fba-eae551a5d4fe"
+    "octgn": "1f28f098-09d4-43fa-8fba-eae551a5d4fe",
+    "categories": "Resource Smoothing"
   },
   {
     "name": "Visionary Leadership",
@@ -5517,7 +5630,8 @@
     "flavor": "`...still the lords of Gondor have keener sight than lesser men...` -Denethor, The Return of the King",
     "textc": "Attach to a Gondor hero.\nWhile attached hero has at least 1 resource in its resource pool, Gondor characters get +1 Willpower.",
     "name_norm": "Visionary Leadership",
-    "octgn": "2f0a3f18-c84f-4458-b6f7-2e6be9acee6b"
+    "octgn": "2f0a3f18-c84f-4458-b6f7-2e6be9acee6b",
+    "categories": ""
   },
   {
     "name": "Spear of the Mark",
@@ -5532,10 +5646,11 @@
     "traits": " Item. Weapon.",
     "keywords": "Restricted.",
     "text": "Attach to a Rohan character.\nAttached character gets +1 Attack. (+2 Attack instead if attacking an enemy in the staging area).",
-    "flavor": "Right through the press drove Théoden Thengel's son, and his spear was shivered as he threw down thier chieftan. -The Return of the King",
+    "flavor": "Right through the press drove Th\u00e9oden Thengel's son, and his spear was shivered as he threw down thier chieftan. -The Return of the King",
     "textc": "Restricted.\nAttach to a Rohan character.\nAttached character gets +1 Attack. (+2 Attack instead if attacking an enemy in the staging area).",
     "name_norm": "Spear of the Mark",
-    "octgn": "66d8e628-8ca8-4605-9017-aece027f054f"
+    "octgn": "66d8e628-8ca8-4605-9017-aece027f054f",
+    "categories": ""
   },
   {
     "name": "Forth Eorlingas!",
@@ -5550,10 +5665,11 @@
     "traits": "",
     "keywords": "",
     "text": "Combat Action: Each Rohan hero can be declared as an attacker against enemies in the staging area this phase.",
-    "flavor": "`Oaths ye have taken: now fulfill them all, to lord and land and league of friendship!` -Théoden, The Return of the King",
+    "flavor": "`Oaths ye have taken: now fulfill them all, to lord and land and league of friendship!` -Th\u00e9oden, The Return of the King",
     "textc": "Combat Action: Each Rohan hero can be declared as an attacker against enemies in the staging area this phase.",
     "name_norm": "Forth Eorlingas",
-    "octgn": "80cdd2b5-60cf-4d47-afe7-505b79abcb1b"
+    "octgn": "80cdd2b5-60cf-4d47-afe7-505b79abcb1b",
+    "categories": ""
   },
   {
     "name": "Steed of the Mark",
@@ -5571,7 +5687,8 @@
     "flavor": "...fresh horses were always in readiness to bear his errand-riders to Rohan in the Noth... -The Return of the King",
     "textc": "Attach to a Gondor or Rohan hero.\nResponse: after attached hero commits to a quest, spend 1 resource from attached hero's resource pool to ready attached hero.",
     "name_norm": "Steed of the Mark",
-    "octgn": "90d300da-a557-44b1-a634-d54782ff5e48"
+    "octgn": "90d300da-a557-44b1-a634-d54782ff5e48",
+    "categories": "Readying"
   },
   {
     "name": "Lay of Nimrodel",
@@ -5586,10 +5703,11 @@
     "traits": " Song.",
     "keywords": "",
     "text": "Action: Choose a Spirit hero. Until the end of the phase, that hero gets +1 Willpower for each resource in its resource pool.",
-    "flavor": "An Elven-maid there was of old.\r\nA shining star by day:\r\nHer mantle white was hemmed with hold,\r\nHer shoes of silver-grey.\r\n-The Fellowship of the Ring",
+    "flavor": "An Elven-maid there was of old.\nA shining star by day:\nHer mantle white was hemmed with hold,\nHer shoes of silver-grey.\n-The Fellowship of the Ring",
     "textc": "Action: Choose a Spirit hero. Until the end of the phase, that hero gets +1 Willpower for each resource in its resource pool.",
     "name_norm": "Lay of Nimrodel",
-    "octgn": "b442354c-887d-403e-815b-a11f10a8760d"
+    "octgn": "b442354c-887d-403e-815b-a11f10a8760d",
+    "categories": ""
   },
   {
     "name": "Ered Nimrais Prospector",
@@ -5608,10 +5726,10 @@
     "traits": " Dwarf.",
     "keywords": "",
     "text": "Response: After Ered Nimrais Prospector enters play, discard the top 3 cards of your deck. Then, choose and shuffle 1 card from your discard pile back into your deck.",
-    "flavor": null,
     "textc": "Response: After Ered Nimrais Prospector enters play, discard the top 3 cards of your deck. Then, choose and shuffle 1 card from your discard pile back into your deck.",
     "name_norm": "Ered Nimrais Prospector",
-    "octgn": "3eb1141f-bf1f-401e-a69d-e4df0af2a8ab"
+    "octgn": "3eb1141f-bf1f-401e-a69d-e4df0af2a8ab",
+    "categories": ""
   },
   {
     "name": "Scroll of Isildur",
@@ -5626,10 +5744,10 @@
     "traits": " Record.",
     "keywords": "",
     "text": "Attach to a Lore hero.\nReduce the cost to play Scroll of Isildur by 1 for each hero you control with a printed Lore resource icon.\nAction: Discard Scroll of Isildur to play any Lore event card in your discard pile as if it were in your hand. Then, place that event on the bottom of your deck.",
-    "flavor": null,
     "textc": "Attach to a Lore hero.\nReduce the cost to play Scroll of Isildur by 1 for each hero you control with a printed Lore resource icon.\nAction: Discard Scroll of Isildur to play any Lore event card in your discard pile as if it were in your hand. Then, place that event on the bottom of your deck.",
     "name_norm": "Scroll of Isildur",
-    "octgn": "63c6bd3a-5566-412d-9199-3929d2fc3cf2"
+    "octgn": "63c6bd3a-5566-412d-9199-3929d2fc3cf2",
+    "categories": ""
   },
   {
     "name": "Hidden Cache",
@@ -5644,13 +5762,14 @@
     "traits": "",
     "keywords": "",
     "text": "Response: After Hidden Cache is discarded from your deck, add 2 resources to the resource pool of a hero you control.\nAction: Spend 1 resource to draw 1 card.",
-    "flavor": "...there was a good deal of food jumbled carlessly on shelves and on the ground, among an untidy litter of plunder...\r\n-The Hobbit",
+    "flavor": "...there was a good deal of food jumbled carlessly on shelves and on the ground, among an untidy litter of plunder...\n-The Hobbit",
     "textc": "Response: After Hidden Cache is discarded from your deck, add 2 resources to the resource pool of a hero you control.\nAction: Spend 1 resource to draw 1 card.",
     "name_norm": "Hidden Cache",
-    "octgn": "6a871e9e-fa3e-4556-8730-09aed1a3ec40"
+    "octgn": "6a871e9e-fa3e-4556-8730-09aed1a3ec40",
+    "categories": "Card Draw, Resource Acceleration"
   },
   {
-    "name": "Éomer",
+    "name": "\u00c9omer",
     "type": "1hero",
     "sphere": "2tactics",
     "cost": 10,
@@ -5665,14 +5784,15 @@
     "unique": true,
     "traits": " Rohan. Noble. Warrior.",
     "keywords": "",
-    "text": "Response: After a character leaves play, Éomer gets +2 Attack until the end of the round. (Limit once per round.)",
-    "flavor": "`I am named Éomer son of Éomund, and am called the Third Marshal of Riddermark.` -The Two Towers",
-    "textc": "Response: After a character leaves play, Éomer gets +2 Attack until the end of the round. (Limit once per round.)",
+    "text": "Response: After a character leaves play, \u00c9omer gets +2 Attack until the end of the round. (Limit once per round.)",
+    "flavor": "`I am named \u00c9omer son of \u00c9omund, and am called the Third Marshal of Riddermark.` -The Two Towers",
+    "textc": "Response: After a character leaves play, \u00c9omer gets +2 Attack until the end of the round. (Limit once per round.)",
     "name_norm": "Eomer",
-    "octgn": "21cfb9e9-6777-4bc6-ace6-08fe68e949a4"
+    "octgn": "21cfb9e9-6777-4bc6-ace6-08fe68e949a4",
+    "categories": "Attack Bonus"
   },
   {
-    "name": "Gríma",
+    "name": "Gr\u00edma",
     "type": "1hero",
     "sphere": "4lore",
     "cost": 9,
@@ -5688,10 +5808,11 @@
     "traits": " Rohan. Isengard.",
     "keywords": "",
     "text": "Action: Lower the cost of the next card you play from your hand this round by 1. That card gains Doomed 1. (Limit once per round.)",
-    "flavor": "`Let your counsellor Gríma keep all things till your return - and I pray that we may see it, though no wise man will deem it hopeful.` -The Two Towers",
+    "flavor": "`Let your counsellor Gr\u00edma keep all things till your return - and I pray that we may see it, though no wise man will deem it hopeful.` -The Two Towers",
     "textc": "Action: Lower the cost of the next card you play from your hand this round by 1. That card gains Doomed 1. (Limit once per round.)",
     "name_norm": "Grima hero",
-    "octgn": "b49c3563-b3cd-4f33-b706-c2a721028891"
+    "octgn": "b49c3563-b3cd-4f33-b706-c2a721028891",
+    "categories": ""
   },
   {
     "name": "Saruman",
@@ -5710,10 +5831,10 @@
     "traits": " Istari. Isengard.",
     "keywords": "Doomed 3.",
     "text": "At the end of the round, discard Saruman from play.\n\nResponse: After Saruman enters play, choose a non-unique enemy or location in the staging area. While Saruman is in play, the chosen enemy or location is considered to be out of play.",
-    "flavor": null,
     "textc": "Doomed 3.\nAt the end of the round, discard Saruman from play.\n\nResponse: After Saruman enters play, choose a non-unique enemy or location in the staging area. While Saruman is in play, the chosen enemy or location is considered to be out of play.",
     "name_norm": "Saruman",
-    "octgn": "20250f12-5bfc-4ffc-8e7e-4e3d71276509"
+    "octgn": "20250f12-5bfc-4ffc-8e7e-4e3d71276509",
+    "categories": ""
   },
   {
     "name": "Orthanc Guard",
@@ -5735,7 +5856,8 @@
     "flavor": "`...the keepers of the gate were on the watch for me and told me that Saruman awaited me.` -Gandalf, The Fellowship of the Ring",
     "textc": "Response: After you raise your threat from the Doomed keyword, ready Orthanc Guard.",
     "name_norm": "Orthanc Guard",
-    "octgn": "6f333a3e-6c2f-4f69-9c93-c5f46dc4f339"
+    "octgn": "6f333a3e-6c2f-4f69-9c93-c5f46dc4f339",
+    "categories": ""
   },
   {
     "name": "Isengard Messenger",
@@ -5757,7 +5879,8 @@
     "flavor": "`I have an urgent errand,` he said. `My news is evil.` -Radagast, The Fellowship of the Ring",
     "textc": "Response: After you raise your threat from the Doomed keyword, Isengard Messenger gets +1 Willpower until the end of the round. (Limit twice per round.)",
     "name_norm": "Isengard Messenger",
-    "octgn": "fe60620b-9ea1-4bf8-8d41-e7fd81a28427"
+    "octgn": "fe60620b-9ea1-4bf8-8d41-e7fd81a28427",
+    "categories": ""
   },
   {
     "name": "Westfold Outrider",
@@ -5779,7 +5902,8 @@
     "flavor": "`Erkenbrand of Westfold has drawn off those men he could gather towards his fastness at Helm's Deep. The rest are scattered.`-Rider of Rohan, The Two Towers",
     "textc": "Action: Discard Westfold Outrider to choose an enemy not engaged with you. Engage the chosen enemy.",
     "name_norm": "Westfold Outrider",
-    "octgn": "93a364f6-2a0f-4872-9770-aa7a1bd30d3d"
+    "octgn": "93a364f6-2a0f-4872-9770-aa7a1bd30d3d",
+    "categories": ""
   },
   {
     "name": "Westfold Horse-breeder",
@@ -5801,7 +5925,8 @@
     "flavor": "`They love their horses next to their kin.` -Boromir, The Fellowship of the Ring",
     "textc": "Response: After Westfold Horse-breeder enters play, search the top 10 cards of your deck for a Mount attachment and add it to your hand. Shuffle your deck.",
     "name_norm": "Westfold Horse-breeder",
-    "octgn": "0567c2df-677c-4529-985a-54621088fe58"
+    "octgn": "0567c2df-677c-4529-985a-54621088fe58",
+    "categories": "Card Search"
   },
   {
     "name": "Rohan Warhorse",
@@ -5819,7 +5944,8 @@
     "flavor": "Their horses were of great stature, strong and clean-limbed... -The Two Towers",
     "textc": "Restricted.\nAttach to a Tactics or Rohan hero.\nResponse: After attached hero participates in an attack that destroys an enemy, exhaust Rohan Warhorse to ready attached hero.",
     "name_norm": "Rohan Warhorse",
-    "octgn": "6f8508d7-bb11-4d5c-a077-80a35e00105e"
+    "octgn": "6f8508d7-bb11-4d5c-a077-80a35e00105e",
+    "categories": "Readying"
   },
   {
     "name": "Silver Lamp",
@@ -5837,7 +5963,8 @@
     "flavor": "...one of them uncovered a small lamp that gave out a slender silver beam. -The Fellowship of the Ring",
     "textc": "Attach to a Spirit hero.\nWhile attached hero is ready, shadow cards dealt to enemies engaged with you are dealt face up. (Shadow card effects are still resolved when resolving enemy attacks.)",
     "name_norm": "Silver Lamp",
-    "octgn": "9463354a-3f6d-43e5-acee-0ea42f8b4403"
+    "octgn": "9463354a-3f6d-43e5-acee-0ea42f8b4403",
+    "categories": "Shadow Control"
   },
   {
     "name": "Keys of Orthanc",
@@ -5855,10 +5982,11 @@
     "flavor": "`He has the Key of Orthanc` -Gandalf, The Two Towers",
     "textc": "Attach to a hero.\nResponse: After you raise your threat from the Doomed keyword, exhaust Keys of Othanc to add 1 resource to attached hero's resource pool.",
     "name_norm": "Keys of Orthanc",
-    "octgn": "e6ee53f4-36e4-4671-9d76-8974134d052e"
+    "octgn": "e6ee53f4-36e4-4671-9d76-8974134d052e",
+    "categories": "Resource Acceleration"
   },
   {
-    "name": "Legacy of Númenor",
+    "name": "Legacy of N\u00famenor",
     "type": "4event",
     "sphere": "1leadership",
     "cost": 0,
@@ -5870,10 +5998,11 @@
     "traits": "",
     "keywords": "Doomed 4.",
     "text": "Action: Add 1 resource to each hero's resource pool.",
-    "flavor": "`...in the midst of that valley is a tower of stone called Orthanc. It was not made by Saruman, but by the Men of Númenor long ago: and it is very tall and has many secrets...` -Gandalf, The Fellowship of the Ring",
+    "flavor": "`...in the midst of that valley is a tower of stone called Orthanc. It was not made by Saruman, but by the Men of N\u00famenor long ago: and it is very tall and has many secrets...` -Gandalf, The Fellowship of the Ring",
     "textc": "Doomed 4.\nAction: Add 1 resource to each hero's resource pool.",
     "name_norm": "Legacy of Numenor",
-    "octgn": "b9e3d591-5973-4f35-90b8-d74d0aeabcc7"
+    "octgn": "b9e3d591-5973-4f35-90b8-d74d0aeabcc7",
+    "categories": "Resource Acceleration"
   },
   {
     "name": "Deep Knowledge",
@@ -5891,7 +6020,8 @@
     "flavor": "`His knowledge is deep, but his pride has grown with it...` -Gandalf, The Fellowship of the Ring",
     "textc": "Doomed 2.\nAction: Each player draws 2 cards.",
     "name_norm": "Deep Knowledge",
-    "octgn": "cfba1adb-5d73-4d46-b10b-b3af003f0e90"
+    "octgn": "cfba1adb-5d73-4d46-b10b-b3af003f0e90",
+    "categories": "Card Draw"
   },
   {
     "name": "The Wizard's Voice",
@@ -5909,7 +6039,8 @@
     "flavor": "...it was a delight to hear the voice speaking, all that it said seemed wise and reasonable... -The Two Towers",
     "textc": "Doomed 3.\nAction: Each player chooses 1 enemy engaged with him. Until the end of the phase, each chosen enemy cannot attack the player that chose it.",
     "name_norm": "The Wizard's Voice",
-    "octgn": "c6df7ee6-41e2-4b24-91d6-f4f9f1bd7d94"
+    "octgn": "c6df7ee6-41e2-4b24-91d6-f4f9f1bd7d94",
+    "categories": "Combat Control"
   },
   {
     "name": "Power of Orthanc",
@@ -5927,7 +6058,8 @@
     "flavor": "`But Saruman has long studied the arts of the Enemy himself, and thus we have often been able to forestall him.` -Gandalf, The Fellowship of the Ring",
     "textc": "Doomed 2.\nAction: Each player may choose and discard a Condition attachment from play.",
     "name_norm": "Power of Orthanc",
-    "octgn": "2867f4c6-b458-4caa-bde2-1a6266c094d6"
+    "octgn": "2867f4c6-b458-4caa-bde2-1a6266c094d6",
+    "categories": "Condition Control"
   },
   {
     "name": "The Seeing-stone",
@@ -5945,7 +6077,8 @@
     "flavor": "`...alone it could do nothing but see small images of things far off and days remote.` -Gandalf, The Two Towers",
     "textc": "Doomed 1.\nAction: Search your deck for a card with the Doomed keyword and add it to your hand. Shuffle your deck.",
     "name_norm": "The Seeing-stone",
-    "octgn": "9de50e07-a3a3-4049-908c-c0463aabf91f"
+    "octgn": "9de50e07-a3a3-4049-908c-c0463aabf91f",
+    "categories": "Card Search"
   },
   {
     "name": "Celeborn",
@@ -5967,7 +6100,8 @@
     "flavor": "`...the lord of the Galadhrim is accounted wisest of the Elves of Middle-earth, and a giver of gifts beyond the power of kings.` -Galadriel, The Fellowship of the Ring",
     "textc": "Response: After a Silvan ally enters play, that ally gets +1 Willpower, +1 Attack and +1 Defense until the end of the round.",
     "name_norm": "Celeborn",
-    "octgn": "4c4cccd3-576a-41f1-8b6c-ba11b4cc3d4b"
+    "octgn": "4c4cccd3-576a-41f1-8b6c-ba11b4cc3d4b",
+    "categories": "Attack Bonus, Defense Bonus"
   },
   {
     "name": "Naith Guide",
@@ -5989,7 +6123,8 @@
     "flavor": "`...I shall lead you well...` -Haldir, The Fellowship of the Ring",
     "textc": "Response: After Naith Guide enters play, choose a hero. That hero does not exhaust to quest this round.",
     "name_norm": "Naith Guide",
-    "octgn": "dad6e885-d535-4100-bd9f-4726ea7c7465"
+    "octgn": "dad6e885-d535-4100-bd9f-4726ea7c7465",
+    "categories": ""
   },
   {
     "name": "Swift and Silent",
@@ -6004,10 +6139,11 @@
     "traits": "",
     "keywords": "",
     "text": "Action: Ready a hero you control. Then, if your threat is 20 or less and this is the first time you played a copy of Swift and Silent this round, return this card to your hand instead of discarding it.",
-    "flavor": "A marching host of Elves had come up silently...–The Fellowship of the Ring",
+    "flavor": "A marching host of Elves had come up silently...\u2013The Fellowship of the Ring",
     "textc": "Action: Ready a hero you control. Then, if your threat is 20 or less and this is the first time you played a copy of Swift and Silent this round, return this card to your hand instead of discarding it.",
     "name_norm": "Swift and Silent",
-    "octgn": "921ba9dd-32c3-4dae-892c-4452c298459e"
+    "octgn": "921ba9dd-32c3-4dae-892c-4452c298459e",
+    "categories": "Readying, Secrecy"
   },
   {
     "name": "Firefoot",
@@ -6021,11 +6157,11 @@
     "unique": true,
     "traits": " Mount.",
     "keywords": "Restricted.",
-    "text": "Attach to a Tactics or Rohan hero.\nAttached hero gets +1 Attack (+2 Attack instead if attached hero is Éomer).\nResponse: After attached hero attacks alone, exhaust Firefoot to choose a non-unique enemy engaged with you. Excess damage dealt by this attack is assigned to the chosen enemy.",
-    "flavor": null,
-    "textc": "Restricted.\nAttach to a Tactics or Rohan hero.\nAttached hero gets +1 Attack (+2 Attack instead if attached hero is Éomer).\nResponse: After attached hero attacks alone, exhaust Firefoot to choose a non-unique enemy engaged with you. Excess damage dealt by this attack is assigned to the chosen enemy.",
+    "text": "Attach to a Tactics or Rohan hero.\nAttached hero gets +1 Attack (+2 Attack instead if attached hero is E\u0301omer).\nResponse: After attached hero attacks alone, exhaust Firefoot to choose a non-unique enemy engaged with you. Excess damage dealt by this attack is assigned to the chosen enemy.",
+    "textc": "Restricted.\nAttach to a Tactics or Rohan hero.\nAttached hero gets +1 Attack (+2 Attack instead if attached hero is E\u0301omer).\nResponse: After attached hero attacks alone, exhaust Firefoot to choose a non-unique enemy engaged with you. Excess damage dealt by this attack is assigned to the chosen enemy.",
     "name_norm": "Firefoot",
-    "octgn": "0ee1f1e6-1952-4bad-8ecd-631e80f4ccc0"
+    "octgn": "0ee1f1e6-1952-4bad-8ecd-631e80f4ccc0",
+    "categories": "Attack Bonus, Direct Damage"
   },
   {
     "name": "Close Call",
@@ -6040,10 +6176,11 @@
     "traits": "",
     "keywords": "Doomed X.",
     "text": "Response: Cancel X damage just dealt to a hero.",
-    "flavor": "`That spear-thrust would have skewered a wild boar!`–Aragorn, The Fellowship of the Ring",
+    "flavor": "`That spear-thrust would have skewered a wild boar!`\u2013Aragorn, The Fellowship of the Ring",
     "textc": "Doomed X.\nResponse: Cancel X damage just dealt to a hero.",
     "name_norm": "Close Call",
-    "octgn": "77bb0328-fe88-42a2-af25-2452c51d5e18"
+    "octgn": "77bb0328-fe88-42a2-af25-2452c51d5e18",
+    "categories": ""
   },
   {
     "name": "Blue Mountain Trader",
@@ -6062,10 +6199,10 @@
     "traits": " Dwarf.",
     "keywords": "",
     "text": "Action: Choose another player. That player gains control of Blue Mountain Trader. Then, that player moves 1 resource from the resource pool of a hero he controls to the resource pool of a hero you control, or Blue Mountain Trader is discarded.",
-    "flavor": null,
     "textc": "Action: Choose another player. That player gains control of Blue Mountain Trader. Then, that player moves 1 resource from the resource pool of a hero he controls to the resource pool of a hero you control, or Blue Mountain Trader is discarded.",
     "name_norm": "Blue Mountain Trader",
-    "octgn": "6840ef99-d0e6-4450-b46f-ad04fee2e78c"
+    "octgn": "6840ef99-d0e6-4450-b46f-ad04fee2e78c",
+    "categories": ""
   },
   {
     "name": "The Fall of Gil-galad",
@@ -6081,10 +6218,11 @@
     "traits": " Song.",
     "keywords": "",
     "text": "Limit 1 per deck. Attach to a hero.\nResponse: When attached hero is destroyed, add The Fall of Gil-galad to the victory display to reduce your threat by X, where X is the attached hero's threat cost.",
-    "flavor": "...for into darkness fell his star\nin Mordor where the shadows are.\n–The Fellowship of the Ring",
+    "flavor": "...for into darkness fell his star\nin Mordor where the shadows are.\n\u2013The Fellowship of the Ring",
     "textc": "Limit 1 per deck. Attach to a hero.\nResponse: When attached hero is destroyed, add The Fall of Gil-galad to the victory display to reduce your threat by X, where X is the attached hero's threat cost.",
     "name_norm": "The Fall of Gil-galad",
-    "octgn": "657e60d4-788e-4064-a8c3-e62584320872"
+    "octgn": "657e60d4-788e-4064-a8c3-e62584320872",
+    "categories": "Threat Control"
   },
   {
     "name": "Ithilien Lookout",
@@ -6103,10 +6241,11 @@
     "traits": " Gondor. Ranger.",
     "keywords": "Secrecy 2.",
     "text": "Response: After Ithilien Lookout enters play, look at the top card of the encounter deck. If it is an enemy, you may discard it.",
-    "flavor": "All had swords at their sides... –The Two Towers",
+    "flavor": "All had swords at their sides... \u2013The Two Towers",
     "textc": "Secrecy 2.\nResponse: After Ithilien Lookout enters play, look at the top card of the encounter deck. If it is an enemy, you may discard it.",
     "name_norm": "Ithilien Lookout",
-    "octgn": "86edf661-e3d8-4372-9325-f2d2d5ac354a"
+    "octgn": "86edf661-e3d8-4372-9325-f2d2d5ac354a",
+    "categories": "Secrecy"
   },
   {
     "name": "The Tree People",
@@ -6121,16 +6260,17 @@
     "traits": "",
     "keywords": "",
     "text": "Action: Return a Silvan ally you control to your hand to search the top 5 cards of your deck for a Silvan ally. Put that ally into play and shuffle the other cards back into your deck. You can only play 1 copy of The Tree People each phase.",
-    "flavor": "No folk could they see, nor hear any feet upon the paths; but there were many voices, about them, and in the air above. –The Fellowship of the Ring",
+    "flavor": "No folk could they see, nor hear any feet upon the paths; but there were many voices, about them, and in the air above. \u2013The Fellowship of the Ring",
     "textc": "Action: Return a Silvan ally you control to your hand to search the top 5 cards of your deck for a Silvan ally. Put that ally into play and shuffle the other cards back into your deck. You can only play 1 copy of The Tree People each phase.",
     "name_norm": "The Tree People",
-    "octgn": "f39eaad9-134d-406b-9111-e03c33e0cd16"
+    "octgn": "f39eaad9-134d-406b-9111-e03c33e0cd16",
+    "categories": "Card Search"
   },
   {
     "name": "The White Council",
     "type": "4event",
     "sphere": "5neutral",
-    "cost": "X",
+    "cost": 0,
     "cycle": 7,
     "exp": "tdt",
     "no": 10,
@@ -6139,10 +6279,11 @@
     "traits": "",
     "keywords": "",
     "text": "X is the number of players in the game.\n\nAction: Starting with the first player, each player chooses 1 different option: ready a hero he controls, add 1 resource to the resource pool of\na hero he controls, draw 1 card, or shuffle 1 card from his discard pile into his deck.",
-    "flavor": "`I it was who first summoned the White Council.`\r\n–Galadriel, The Fellowship of the Ring",
+    "flavor": "`I it was who first summoned the White Council.`\n\u2013Galadriel, The Fellowship of the Ring",
     "textc": "X is the number of players in the game.\n\nAction: Starting with the first player, each player chooses 1 different option: ready a hero he controls, add 1 resource to the resource pool of\na hero he controls, draw 1 card, or shuffle 1 card from his discard pile into his deck.",
     "name_norm": "The White Council",
-    "octgn": "07d3df19-30b4-493c-a8b0-b38695322e71"
+    "octgn": "07d3df19-30b4-493c-a8b0-b38695322e71",
+    "categories": "Card Draw, Readying, Resource Acceleration"
   },
   {
     "name": "Idraen",
@@ -6158,13 +6299,14 @@
     "no": 25,
     "img": "http://www.cardgamedb.com/forums/uploads/lotr/idraen-the-three-trials-25.jpg",
     "unique": true,
-    "traits": " Dúnedain. Ranger. Scout.",
+    "traits": " D\u00fanedain. Ranger. Scout.",
     "keywords": "",
     "text": "Response: After a location is explored, ready Idraen.",
-    "flavor": "`Where now are the Dúnedain, Elessar, Elessar? Why do thy kinsfolk wander afar?` -Galadriel, The Two Towers",
+    "flavor": "`Where now are the D\u00fanedain, Elessar, Elessar? Why do thy kinsfolk wander afar?` -Galadriel, The Two Towers",
     "textc": "Response: After a location is explored, ready Idraen.",
     "name_norm": "Idraen",
-    "octgn": "df9683da-d86f-46c9-9ef5-66001753dad5"
+    "octgn": "df9683da-d86f-46c9-9ef5-66001753dad5",
+    "categories": ""
   },
   {
     "name": "Rivendell Scout",
@@ -6186,7 +6328,8 @@
     "flavor": "`Elrond is sending Elves, and they will get in touch with the Rangers, and maybe with Thranduil's folk in Mirkwood.` -Gandalf, The Fellowship of the Ring",
     "textc": "Secrecy 2.\n",
     "name_norm": "Rivendell Scout",
-    "octgn": "b1fb86fd-728b-4e1b-950a-73daa2a82753"
+    "octgn": "b1fb86fd-728b-4e1b-950a-73daa2a82753",
+    "categories": ""
   },
   {
     "name": "Feigned Voices",
@@ -6204,10 +6347,11 @@
     "flavor": "`The three of us could not challenge a hundred, so we went ahead and spoke with feigned voices, leading them on into the wood.` -Haldir, The Fellowship of the Ring",
     "textc": "Combat Action: Return a Silvan ally you control to your hand to choose an enemy engaged with a player. That enemy cannot attack that player this phase.",
     "name_norm": "Feigned Voices",
-    "octgn": "14936075-9e6a-43af-9497-dbee9df95781"
+    "octgn": "14936075-9e6a-43af-9497-dbee9df95781",
+    "categories": "Combat Control"
   },
   {
-    "name": "Rúmil",
+    "name": "R\u00famil",
     "type": "2ally",
     "sphere": "2tactics",
     "cost": 4,
@@ -6222,11 +6366,12 @@
     "unique": true,
     "traits": " Silvan. Scout.",
     "keywords": "Ranged.",
-    "text": "Response: After you play Rúmil from your hand, choose an enemy engaged with a player. Deal X damage to that enemy where X is the number of ranged characters you control.",
-    "flavor": "...the Company set out again, guided now by Haldir and his brother Rúmil. -The Fellowship of the Ring",
-    "textc": "Ranged.\nResponse: After you play Rúmil from your hand, choose an enemy engaged with a player. Deal X damage to that enemy where X is the number of ranged characters you control.",
+    "text": "Response: After you play R\u00famil from your hand, choose an enemy engaged with a player. Deal X damage to that enemy where X is the number of ranged characters you control.",
+    "flavor": "...the Company set out again, guided now by Haldir and his brother R\u00famil. -The Fellowship of the Ring",
+    "textc": "Ranged.\nResponse: After you play R\u00famil from your hand, choose an enemy engaged with a player. Deal X damage to that enemy where X is the number of ranged characters you control.",
     "name_norm": "Rumil",
-    "octgn": "4b794779-c6b6-4ee0-b13f-196b721e28a7"
+    "octgn": "4b794779-c6b6-4ee0-b13f-196b721e28a7",
+    "categories": "Direct Damage"
   },
   {
     "name": "Elven Mail",
@@ -6244,7 +6389,8 @@
     "flavor": "...they were tall and and clad in grey mail, and from their shoulders hung long white cloaks. -The Fellowship of the Ring",
     "textc": "Restricted.\nAttach to a Noldor or Silvan character.\nAttached character gets +2 hit points and gains sentinel.",
     "name_norm": "Elven Mail",
-    "octgn": "6b86cf8e-1708-434d-90a5-93163f3d61ea"
+    "octgn": "6b86cf8e-1708-434d-90a5-93163f3d61ea",
+    "categories": "Hit Point Bonus"
   },
   {
     "name": "Greyflood Wanderer",
@@ -6260,13 +6406,14 @@
     "no": 30,
     "img": "http://www.cardgamedb.com/forums/uploads/lotr/greyflood-wanderer-the-three-trials-30.jpg",
     "unique": false,
-    "traits": " Dúnedain. Scout.",
+    "traits": " D\u00fanedain. Scout.",
     "keywords": "",
     "text": "You may give Greyflood Wanderer doomed 2 when you play from your hand. If you do, it gains: `Response: After you play Greyflood Wanderer, place 1 progress token on each location in play.`",
     "flavor": "...others had gone west, and with the help of Aragorn and the Rangers had searched the lands far down the Greyflood... -The Fellowship of the Ring",
     "textc": "You may give Greyflood Wanderer doomed 2 when you play from your hand. If you do, it gains: `Response: After you play Greyflood Wanderer, place 1 progress token on each location in play.`",
     "name_norm": "Greyflood Wanderer",
-    "octgn": "284838f8-1ea0-466f-a373-032c7ad6e836"
+    "octgn": "284838f8-1ea0-466f-a373-032c7ad6e836",
+    "categories": ""
   },
   {
     "name": "Warden of Arnor",
@@ -6284,7 +6431,8 @@
     "flavor": "`I have had a hard life and a long: and the leagues that lie between here and Gondor are a small part in the count of my journeys.` -Aragorn, The Fellowship of the Ring",
     "textc": "Attach to a Scout hero.\nWhile attached character is committed to the quest, place 1 progress on the first location revealed by the encounter deck each round.",
     "name_norm": "Warden of Arnor",
-    "octgn": "f9b39223-3b12-4682-8db5-9ef4116b4919"
+    "octgn": "f9b39223-3b12-4682-8db5-9ef4116b4919",
+    "categories": ""
   },
   {
     "name": "Message from Elrond",
@@ -6299,10 +6447,11 @@
     "traits": "",
     "keywords": "",
     "text": "Action: Choose a player. That player may choose 1 card from his hand and add it to another player's hand. At the end of the round, if the chosen card is in that player's hand or in play, shuffle it into its owner's deck.",
-    "flavor": "`But we have heard rumours of your coming, for the messengers of Elrond passed by Lórien on the way home up the Dimrill Stair. -Haldir, The Fellowship of the Ring",
+    "flavor": "`But we have heard rumours of your coming, for the messengers of Elrond passed by L\u00f3rien on the way home up the Dimrill Stair. -Haldir, The Fellowship of the Ring",
     "textc": "Action: Choose a player. That player may choose 1 card from his hand and add it to another player's hand. At the end of the round, if the chosen card is in that player's hand or in play, shuffle it into its owner's deck.",
     "name_norm": "Message from Elrond",
-    "octgn": "cc4b0912-ba4a-44b6-b7c5-2c0f0b325ebf"
+    "octgn": "cc4b0912-ba4a-44b6-b7c5-2c0f0b325ebf",
+    "categories": ""
   },
   {
     "name": "Noiseless Movement",
@@ -6320,7 +6469,8 @@
     "flavor": "...the woodland folk were altogether noiseless in their movements. -The Fellowship of the Ring",
     "textc": "Action: Choose an enemy in the staging area. That enemy does not make engagement checks this round. Then, if your threat is 20 or less and this is the first time you played a copy of Noiseless Movement this round, return this card to your hand instead of discarding it.",
     "name_norm": "Noiseless Movement",
-    "octgn": "b520fbc1-3cb9-49aa-9b37-2dad3b3ba333"
+    "octgn": "b520fbc1-3cb9-49aa-9b37-2dad3b3ba333",
+    "categories": "Secrecy"
   },
   {
     "name": "Leaf Brooch",
@@ -6338,10 +6488,11 @@
     "flavor": "Each cloak was fastened about the neck with a brooch like a green leaf veined with silver. -The Fellowship of the Ring",
     "textc": "Attach to a hero. Limit 1 per hero.\nThe first event card you play each round that matches attached hero's printed sphere gains secrecy 1.",
     "name_norm": "Leaf Brooch",
-    "octgn": "1c692a1a-4ccf-4185-b5bd-d2b8d300de42"
+    "octgn": "1c692a1a-4ccf-4185-b5bd-d2b8d300de42",
+    "categories": "Secrecy"
   },
   {
-    "name": "Haldir of Lórien",
+    "name": "Haldir of L\u00f3rien",
     "type": "1hero",
     "sphere": "4lore",
     "cost": 9,
@@ -6356,14 +6507,15 @@
     "unique": true,
     "traits": " Silvan. Ranger. Scout.",
     "keywords": "Ranged.",
-    "text": "Combat Action: If you have not engaged an enemy this round, exhaust Haldir of Lórien to declare him as an attacker (and resolve his attack) against an enemy not engaged with you. Limit once per round.",
+    "text": "Combat Action: If you have not engaged an enemy this round, exhaust Haldir of L\u00f3rien to declare him as an attacker (and resolve his attack) against an enemy not engaged with you. Limit once per round.",
     "flavor": "`We allow no strangers to spy out the secrets of the Naith...` -The Fellowship of the Ring",
-    "textc": "Ranged.\nCombat Action: If you have not engaged an enemy this round, exhaust Haldir of Lórien to declare him as an attacker (and resolve his attack) against an enemy not engaged with you. Limit once per round.",
+    "textc": "Ranged.\nCombat Action: If you have not engaged an enemy this round, exhaust Haldir of L\u00f3rien to declare him as an attacker (and resolve his attack) against an enemy not engaged with you. Limit once per round.",
     "name_norm": "Haldir of Lorien",
-    "octgn": "9d548a43-0ef8-45e6-ab95-7356d218d203"
+    "octgn": "9d548a43-0ef8-45e6-ab95-7356d218d203",
+    "categories": ""
   },
   {
-    "name": "Herald of Anórien",
+    "name": "Herald of An\u00f3rien",
     "type": "2ally",
     "sphere": "1leadership",
     "cost": 2,
@@ -6378,14 +6530,15 @@
     "unique": false,
     "traits": " Gondor.",
     "keywords": "",
-    "text": "You may give Herald of Anórien doomed 2 when you play it from your hand. If you do, it gains: `Response: After you play Herald of Anórien, choose a player. That player may put into play 1 ally from his hand with a printed cost 2 or lower.`",
-    "flavor": "`Send the heralds forth! Let them summon all who dwell nigh!` -Théoden, The Two Towers",
-    "textc": "You may give Herald of Anórien doomed 2 when you play it from your hand. If you do, it gains: `Response: After you play Herald of Anórien, choose a player. That player may put into play 1 ally from his hand with a printed cost 2 or lower.`",
+    "text": "You may give Herald of An\u00f3rien doomed 2 when you play it from your hand. If you do, it gains: `Response: After you play Herald of An\u00f3rien, choose a player. That player may put into play 1 ally from his hand with a printed cost 2 or lower.`",
+    "flavor": "`Send the heralds forth! Let them summon all who dwell nigh!` -Th\u00e9oden, The Two Towers",
+    "textc": "You may give Herald of An\u00f3rien doomed 2 when you play it from your hand. If you do, it gains: `Response: After you play Herald of An\u00f3rien, choose a player. That player may put into play 1 ally from his hand with a printed cost 2 or lower.`",
     "name_norm": "Herald of Anorien",
-    "octgn": "8c6be9f6-f97c-40a9-88da-2f3ba7f640ed"
+    "octgn": "8c6be9f6-f97c-40a9-88da-2f3ba7f640ed",
+    "categories": ""
   },
   {
-    "name": "O Lórien",
+    "name": "O L\u00f3rien",
     "type": "3attachment",
     "sphere": "1leadership",
     "cost": 1,
@@ -6397,10 +6550,11 @@
     "traits": " Song.",
     "keywords": "",
     "text": "Attach to a hero.\nAction: Exhaust O Lorien! to lower the cost of the next Silvan ally played this phase by 1 (to a minimum of 1).",
-    "flavor": "`I sang of leaves, of leaves of gold, and\r\nleaves of gold there grew:\r\nOf wind I sang, a wind there came and in the\r\nbranches blew.` -Galadriel, The Fellowship of the Ring",
+    "flavor": "`I sang of leaves, of leaves of gold, and\nleaves of gold there grew:\nOf wind I sang, a wind there came and in the\nbranches blew.` -Galadriel, The Fellowship of the Ring",
     "textc": "Attach to a hero.\nAction: Exhaust O Lorien! to lower the cost of the next Silvan ally played this phase by 1 (to a minimum of 1).",
     "name_norm": "O Lorien",
-    "octgn": "b4d93180-0ebc-4a9b-9817-e761068570e3"
+    "octgn": "b4d93180-0ebc-4a9b-9817-e761068570e3",
+    "categories": ""
   },
   {
     "name": "Gwaihir",
@@ -6422,7 +6576,8 @@
     "flavor": "`The North Wind blows, but we shall outfly it.` -Gwaihir, The Return of the King",
     "textc": "Cannot have restricted attachments.\nResponse: After Gwaihir enters play, search your discard pile for an Eagle ally and put it into play under your control. At the end of the round, if that ally is still in play, add it to your hand.",
     "name_norm": "Gwaihir",
-    "octgn": "2e7f22cc-218e-4dad-b4e4-00b2208713d9"
+    "octgn": "2e7f22cc-218e-4dad-b4e4-00b2208713d9",
+    "categories": ""
   },
   {
     "name": "Pursuing the Enemy",
@@ -6440,7 +6595,8 @@
     "flavor": "The marauding orcs had been waylaid and almost all destroyed; the remnant had fled westward towards the mountains, and were being pursued. -The Fellowship of the Ring",
     "textc": "Action: Return a Silvan ally you control to your hand to choose a player. Deal 1 damage to each enemy engaged with that player.",
     "name_norm": "Pursuing the Enemy",
-    "octgn": "af74e00e-a04e-4a15-a538-d36539bfb751"
+    "octgn": "af74e00e-a04e-4a15-a538-d36539bfb751",
+    "categories": "Direct Damage"
   },
   {
     "name": "Courage Awakened",
@@ -6458,7 +6614,8 @@
     "flavor": "But the courage that had been awakened in him was now too strong: he could not leave his friends so easily. -The Fellowship of the Ring",
     "textc": "Action: Choose a hero. That hero gets +2 Willpower until the end of the phase. Then, if your threat is 20 or less and this is the first time you played a copy of Courage Awakened this round, return this card to your hand instead of discarding it.",
     "name_norm": "Courage Awakened",
-    "octgn": "72ec977b-6d24-459c-aaa8-49c2a01f0766"
+    "octgn": "72ec977b-6d24-459c-aaa8-49c2a01f0766",
+    "categories": "Secrecy"
   },
   {
     "name": "Free to Choose",
@@ -6476,7 +6633,8 @@
     "flavor": "Suddenly he was aware of himself again. Frodo, neither the Voice nor the Eye; free to choose, and with one remaining instant in which to do so. -The Fellowship of the Ring",
     "textc": "Response: After your threat is raised by an encounter card effect, reduce your threat by an equal amount.",
     "name_norm": "Free to Choose",
-    "octgn": "0d0b210e-995a-4ded-b7b0-d32b59dbaa4f"
+    "octgn": "0d0b210e-995a-4ded-b7b0-d32b59dbaa4f",
+    "categories": "Threat Control"
   },
   {
     "name": "Galadhrim Minstrel",
@@ -6498,7 +6656,8 @@
     "flavor": "...the language was that of Elven-song and spoke of things little known on Middle-earth. -The Fellowship of the Ring",
     "textc": "Response: After Galadhrim Minstrel enters play, search the top five cards of your deck for an event card and add it to your hand. Shuffle the other cards back into your deck.",
     "name_norm": "Galadhrim Minstrel",
-    "octgn": "bd81ff6a-9c8f-415e-85fb-da84c21ef2a4"
+    "octgn": "bd81ff6a-9c8f-415e-85fb-da84c21ef2a4",
+    "categories": "Card Search"
   },
   {
     "name": "Lembas",
@@ -6513,10 +6672,11 @@
     "traits": " Item.",
     "keywords": "",
     "text": "Play only if you control a Noldor or Silvan hero. Attach to a hero.\nAction: Discard Lembas to ready attached hero and heal 3 damage from it.",
-    "flavor": "`...it is more strengthing than any food made by Men, and it is more pleasant than cram, by all accounts. -Lórien Elf, The Fellowship of the Ring",
+    "flavor": "`...it is more strengthing than any food made by Men, and it is more pleasant than cram, by all accounts. -L\u00f3rien Elf, The Fellowship of the Ring",
     "textc": "Play only if you control a Noldor or Silvan hero. Attach to a hero.\nAction: Discard Lembas to ready attached hero and heal 3 damage from it.",
     "name_norm": "Lembas",
-    "octgn": "f86ea37a-d70d-4ff2-ac36-2a0ff1f7ffa9"
+    "octgn": "f86ea37a-d70d-4ff2-ac36-2a0ff1f7ffa9",
+    "categories": "Healing, Readying"
   },
   {
     "name": "Defender of the Naith",
@@ -6538,7 +6698,8 @@
     "flavor": "`We have been keeping watch on the rivers, ever since we saw a great troop of Orcs going North toward Moria...` -Haldir, The Fellowship of the Ring",
     "textc": "Sentinel.\nResponse: After a Silvan ally you control leaves play, ready Defender of the Naith.",
     "name_norm": "Defender of the Naith",
-    "octgn": "b91ba94d-e6b9-41f6-89ed-df1fb1f22335"
+    "octgn": "b91ba94d-e6b9-41f6-89ed-df1fb1f22335",
+    "categories": ""
   },
   {
     "name": "Mablung",
@@ -6557,10 +6718,11 @@
     "traits": " Gondor. Ranger.",
     "keywords": "",
     "text": "Response: After you engage an enemy, add 1 resource to Mablung's resource pool. (Limit once per phase.)",
-    "flavor": "But the Captains of the West were well warned by their scouts, skilled men from Henneth Annûn led by Mablung...\r\n-The Return of the King",
+    "flavor": "But the Captains of the West were well warned by their scouts, skilled men from Henneth Ann\u00fbn led by Mablung...\n-The Return of the King",
     "textc": "Response: After you engage an enemy, add 1 resource to Mablung's resource pool. (Limit once per phase.)",
     "name_norm": "Mablung",
-    "octgn": "9e3a4b3b-7bb7-4403-984c-411af5ec8467"
+    "octgn": "9e3a4b3b-7bb7-4403-984c-411af5ec8467",
+    "categories": "Resource Acceleration"
   },
   {
     "name": "Follow Me!",
@@ -6575,10 +6737,11 @@
     "traits": "",
     "keywords": "",
     "text": "Action: Take control of the first player token and draw 1 card.",
-    "flavor": "`Come! I will lead you now!`\r\n-Aragorn, The Fellowship of the Ring",
+    "flavor": "`Come! I will lead you now!`\n-Aragorn, The Fellowship of the Ring",
     "textc": "Action: Take control of the first player token and draw 1 card.",
     "name_norm": "Follow Me!",
-    "octgn": "b86c3959-86af-4ce4-927f-769b873e4774"
+    "octgn": "b86c3959-86af-4ce4-927f-769b873e4774",
+    "categories": ""
   },
   {
     "name": "Tighten Our Belts",
@@ -6596,7 +6759,8 @@
     "flavor": "There was nothing now to be done but to tighten the belts round their empty stomachs, and hoist their empty sacks and packs... -The Hobbit",
     "textc": "Refresh Action: Choose a player. Each hero that player controls that did not spend any resources this round gains 1 resource. Only 1 copy of Tighten Our Belts can be played by the players each round.",
     "name_norm": "Tighten Our Belts",
-    "octgn": "e1ff74ae-0c48-4f6c-86c8-9ac7339eb554"
+    "octgn": "e1ff74ae-0c48-4f6c-86c8-9ac7339eb554",
+    "categories": ""
   },
   {
     "name": "Galadhon Archer",
@@ -6618,7 +6782,8 @@
     "flavor": "`...they say that you breathe so loud that they could shoot you in the dark.` -Legolas, The Fellowship of the Ring",
     "textc": "Ranged.\nResponse: After Galadhon Archer enters play, deal 1 damage to an enemy not engaged with you.",
     "name_norm": "Galadhon Archer",
-    "octgn": "39775f69-5cf4-4133-9cf4-45a1522aa9ea"
+    "octgn": "39775f69-5cf4-4133-9cf4-45a1522aa9ea",
+    "categories": "Direct Damage"
   },
   {
     "name": "Bow of the Galadhrim",
@@ -6636,7 +6801,8 @@
     "flavor": "...longer and stronger than the bows of Mirkwood, and strung with a string of elf-hair. -The Fellowship of the Ring",
     "textc": "Restricted.\nAttach to a Silvan character with the ranged keyword.\nAttached character gets +1 Attack. (+2 Attack instead if attacking an enemy not engaged with you.)",
     "name_norm": "Bow of the Galadhrim",
-    "octgn": "12d436ac-15e6-47c5-8288-357c918071a7"
+    "octgn": "12d436ac-15e6-47c5-8288-357c918071a7",
+    "categories": ""
   },
   {
     "name": "Celduin Traveler",
@@ -6658,7 +6824,8 @@
     "flavor": "In two days going they rowed right up the Long Lake and passed out into the River Running... -The Hobbit",
     "textc": "Secrecy 2.\nResponse: After Celduin Traveler enters play, look at the top card of the encounter deck. If it is a location, you may discard it.",
     "name_norm": "Celduin Traveler",
-    "octgn": "c541b65a-d6d4-4b2c-8925-96c31d52aa1c"
+    "octgn": "c541b65a-d6d4-4b2c-8925-96c31d52aa1c",
+    "categories": "Secrecy"
   },
   {
     "name": "Island Amid Perils",
@@ -6673,10 +6840,11 @@
     "traits": "",
     "keywords": "",
     "text": "Action: Return a Silvan you control to your hand to reduce your threat by X where X is the printed cost of the ally returned to your hand.",
-    "flavor": "`...we dare not by our own trust endanger our land. We live now upon an island amid many perils...` \r\n-Haldir, The Fellowship of the Ring",
+    "flavor": "`...we dare not by our own trust endanger our land. We live now upon an island amid many perils...` \n-Haldir, The Fellowship of the Ring",
     "textc": "Action: Return a Silvan you control to your hand to reduce your threat by X where X is the printed cost of the ally returned to your hand.",
     "name_norm": "Island Amid Perils",
-    "octgn": "26a52bdc-f8e4-40a3-8047-8d696b842cdf"
+    "octgn": "26a52bdc-f8e4-40a3-8047-8d696b842cdf",
+    "categories": "Threat Control"
   },
   {
     "name": "Mirkwood Pioneer",
@@ -6695,10 +6863,10 @@
     "traits": " Woodman.",
     "keywords": "",
     "text": "You may give Mirkwood Pioneer doomed 1 when you play it from your hand. If you do it gains: `Response: After you play Mirkwood Pioneer, choose a card in the staging area. Until the end of the round, the chosen card does not contribute its Threat.`",
-    "flavor": null,
     "textc": "You may give Mirkwood Pioneer doomed 1 when you play it from your hand. If you do it gains: `Response: After you play Mirkwood Pioneer, choose a card in the staging area. Until the end of the round, the chosen card does not contribute its Threat.`",
     "name_norm": "Mirkwood Pioneer",
-    "octgn": "c75056aa-907b-40b8-a54a-18ea07b33dc3"
+    "octgn": "c75056aa-907b-40b8-a54a-18ea07b33dc3",
+    "categories": ""
   },
   {
     "name": "Wingfoot",
@@ -6713,10 +6881,11 @@
     "traits": " Title.",
     "keywords": "",
     "text": "Attach to a Ranger hero.\nResponse: After attached hero commits to a quest. name enemy, location or treachery. If a card of the named type is revealed during this quest phase, ready attached hero.",
-    "flavor": "`Wingfoot I name you. This deed of the three friends should be sung in many a hall. Forty leagues and five you have measured ere the forth day is ended!`\r\n-Éomer, The Two Towers",
+    "flavor": "`Wingfoot I name you. This deed of the three friends should be sung in many a hall. Forty leagues and five you have measured ere the forth day is ended!`\n-\u00c9omer, The Two Towers",
     "textc": "Attach to a Ranger hero.\nResponse: After attached hero commits to a quest. name enemy, location or treachery. If a card of the named type is revealed during this quest phase, ready attached hero.",
     "name_norm": "Wingfoot",
-    "octgn": "17cb8a9a-6369-4ea9-a614-02908bd7b77f"
+    "octgn": "17cb8a9a-6369-4ea9-a614-02908bd7b77f",
+    "categories": ""
   },
   {
     "name": "Defender of the West",
@@ -6731,10 +6900,11 @@
     "traits": " Title.",
     "keywords": "",
     "text": "Attach to a non-objective unique ally in play.\nThe first player gains control of attached ally.\nDamage from undefended attacks against you may be assigned to attached ally.",
-    "flavor": "`...if by life or death I can save you, I will.`\r\n-Aragorn, The Fellowship of the Ring",
+    "flavor": "`...if by life or death I can save you, I will.`\n-Aragorn, The Fellowship of the Ring",
     "textc": "Attach to a non-objective unique ally in play.\nThe first player gains control of attached ally.\nDamage from undefended attacks against you may be assigned to attached ally.",
     "name_norm": "Defender of the West",
-    "octgn": "a1f5a577-30bf-44ed-b60b-e733b5f26d55"
+    "octgn": "a1f5a577-30bf-44ed-b60b-e733b5f26d55",
+    "categories": ""
   },
   {
     "name": "Galadriel",
@@ -6753,10 +6923,10 @@
     "traits": " Noldor. Noble.",
     "keywords": "",
     "text": "Galadriel cannot quest, attack, or defend. Allies you control do not exhaust to commit to the quest during the round they enter play.\n\nAction: Exhaust Galadriel to choose a player. That player reduces his threat by 1 and draws 1 card. (Limit once per round.)",
-    "flavor": null,
     "textc": "Galadriel cannot quest, attack, or defend. Allies you control do not exhaust to commit to the quest during the round they enter play.\n\nAction: Exhaust Galadriel to choose a player. That player reduces his threat by 1 and draws 1 card. (Limit once per round.)",
     "name_norm": "Galadriel",
-    "octgn": "8d6a15a8-e363-46bb-8e49-0af45a1ea0d1"
+    "octgn": "8d6a15a8-e363-46bb-8e49-0af45a1ea0d1",
+    "categories": "Card Draw, Card Search, Threat Control"
   },
   {
     "name": "Heir of Mardil",
@@ -6771,10 +6941,11 @@
     "traits": " Title.",
     "keywords": "",
     "text": "Attach to a Noble hero.\n\nResponse: After attached hero gains any number of resources from a card effect, exhaust Heir of Mardil to ready attached hero.",
-    "flavor": "`...in my turn I bore it, and so did each eldest son of our house, far back into the vanished years before the failing of the kings...`\r\n-Denethor, The Return of the King",
+    "flavor": "`...in my turn I bore it, and so did each eldest son of our house, far back into the vanished years before the failing of the kings...`\n-Denethor, The Return of the King",
     "textc": "Attach to a Noble hero.\n\nResponse: After attached hero gains any number of resources from a card effect, exhaust Heir of Mardil to ready attached hero.",
     "name_norm": "Heir of Mardil",
-    "octgn": "83842580-bfe9-4d56-addf-e1d290eb7bcf"
+    "octgn": "83842580-bfe9-4d56-addf-e1d290eb7bcf",
+    "categories": "Readying"
   },
   {
     "name": "Orophin",
@@ -6796,10 +6967,11 @@
     "flavor": "`Orophin has now gone in haste back to our dwellings to warn our people.` -Haldir, The Fellowship of the Ring",
     "textc": "Ranged.\nResponse: After Orophin enters play, return a Silvan ally from your discard pile to your hand.",
     "name_norm": "Orophin",
-    "octgn": "9220dbae-e7fc-43fc-b772-043af7d4bda1"
+    "octgn": "9220dbae-e7fc-43fc-b772-043af7d4bda1",
+    "categories": ""
   },
   {
-    "name": "Henneth Annûn Guard",
+    "name": "Henneth Ann\u00fbn Guard",
     "type": "2ally",
     "sphere": "2tactics",
     "cost": 3,
@@ -6814,11 +6986,12 @@
     "unique": false,
     "traits": " Gondor. Warrior.",
     "keywords": "",
-    "text": "You may give Henneth Annûn Guard doomed 1 when you play it from your hand. If you do, it gains :`Response: After you play Henneth Annûn Guard, choose a character. Until the end of the round, that character gets +2 Defense and gains sentinel.`",
+    "text": "You may give Henneth Ann\u00fbn Guard doomed 1 when you play it from your hand. If you do, it gains :`Response: After you play Henneth Ann\u00fbn Guard, choose a character. Until the end of the round, that character gets +2 Defense and gains sentinel.`",
     "flavor": "`Does he think that men sleep without watch all night?` -Faramir, The Two Towers",
-    "textc": "You may give Henneth Annûn Guard doomed 1 when you play it from your hand. If you do, it gains :`Response: After you play Henneth Annûn Guard, choose a character. Until the end of the round, that character gets +2 Defense and gains sentinel.`",
+    "textc": "You may give Henneth Ann\u00fbn Guard doomed 1 when you play it from your hand. If you do, it gains :`Response: After you play Henneth Ann\u00fbn Guard, choose a character. Until the end of the round, that character gets +2 Defense and gains sentinel.`",
     "name_norm": "Henneth Annun Guard",
-    "octgn": "05577e9f-477b-4842-8491-32c748c1a0e4"
+    "octgn": "05577e9f-477b-4842-8491-32c748c1a0e4",
+    "categories": "Defense Bonus"
   },
   {
     "name": "Charge of the Rohirrim",
@@ -6833,10 +7006,11 @@
     "traits": "",
     "keywords": "",
     "text": "Action: Until the end of the phase, each Rohan character with a Mount attachment gets +3 Attack.",
-    "flavor": "`Arise, arise, riders of Théoden!` -Théoden, The Return of the King",
+    "flavor": "`Arise, arise, riders of Th\u00e9oden!` -Th\u00e9oden, The Return of the King",
     "textc": "Action: Until the end of the phase, each Rohan character with a Mount attachment gets +3 Attack.",
     "name_norm": "Charge of the Rohirrim",
-    "octgn": "4fb48ed9-1651-4ae7-83d1-9d76a1dc27e7"
+    "octgn": "4fb48ed9-1651-4ae7-83d1-9d76a1dc27e7",
+    "categories": "Attack Bonus"
   },
   {
     "name": "Galadriel's Handmaiden",
@@ -6858,7 +7032,8 @@
     "flavor": "Her maidens stood silent about her, and a while she looked upon her guests. -The Fellowship of the Ring",
     "textc": "Response: After Galadriel's Handmaiden enters play, choose a player. That player reduces his threat by 1.",
     "name_norm": "Galadriel's Handmaiden",
-    "octgn": "ff3794e8-d8b1-48dc-a9f8-97ea7d6b3874"
+    "octgn": "ff3794e8-d8b1-48dc-a9f8-97ea7d6b3874",
+    "categories": "Threat Control"
   },
   {
     "name": "Mirror of Galadriel",
@@ -6873,10 +7048,11 @@
     "traits": " Artifact. Item.",
     "keywords": "",
     "text": "Attach to Galadriel.\n\nExhaust Mirror of Galadriel to search the top 10 cards of your deck for a card and add it to your hand. Shuffle the rest back into your deck. Then, discard a random card from your hand.",
-    "flavor": "`What you will see, if you leave the Mirror free to work, I cannot tell. For it shows things that were, things that are, things that yet may be.`\r\n-Galadriel, The Fellowship of the Ring",
+    "flavor": "`What you will see, if you leave the Mirror free to work, I cannot tell. For it shows things that were, things that are, things that yet may be.`\n-Galadriel, The Fellowship of the Ring",
     "textc": "Attach to Galadriel.\n\nExhaust Mirror of Galadriel to search the top 10 cards of your deck for a card and add it to your hand. Shuffle the rest back into your deck. Then, discard a random card from your hand.",
     "name_norm": "Mirror of Galadriel",
-    "octgn": "6e97a705-2458-4aa1-ad90-f3cd8200ca5a"
+    "octgn": "6e97a705-2458-4aa1-ad90-f3cd8200ca5a",
+    "categories": "Card Draw, Card Search"
   },
   {
     "name": "Wandering Ent",
@@ -6898,10 +7074,11 @@
     "flavor": "There were songs about the hunt of the Ents for the Entwives sung among Elves and Men from Mirkwood to Gondor. -The Two Towers",
     "textc": "Cannot have restricted attachments.\nEnters play exhausted.",
     "name_norm": "Wandering Ent",
-    "octgn": "496b62d9-2e7c-4206-bae5-2b180fec84d1"
+    "octgn": "496b62d9-2e7c-4206-bae5-2b180fec84d1",
+    "categories": ""
   },
   {
-    "name": "Cloak of Lórien",
+    "name": "Cloak of L\u00f3rien",
     "type": "3attachment",
     "sphere": "4lore",
     "cost": 1,
@@ -6916,7 +7093,8 @@
     "flavor": "It was hard to say what colour they were: grey with the hue of twilight under the trees they seemed to be; and yet if they were moved, or set in another light, they were green as shadowed leaves... -The Fellowship of the Ring",
     "textc": "Attach to a Noldor or Silvan character.\nLimit 1 per character.\nAttached character gets +1 Defense (+2 Defense instead if the active location has the Forest trait).",
     "name_norm": "Cloak of Lorien",
-    "octgn": "f40cc90c-02df-464b-a401-6640aa93e2f8"
+    "octgn": "f40cc90c-02df-464b-a401-6640aa93e2f8",
+    "categories": "Defense Bonus"
   },
   {
     "name": "Nenya",
@@ -6934,7 +7112,8 @@
     "flavor": "`The is Nenya, the Ring of Adamant, and I am its keeper.` -Galadriel, The Fellowship of the Ring",
     "textc": "Attach to Galadriel. She gains a Lore resource icon.\nQuest Action: Exhaust Nenya and Galadriel to add her Willpower to another character's Willpower until the end of the phase.",
     "name_norm": "Nenya",
-    "octgn": "17ed9b53-19f5-4ad1-ab91-14c2859e5a60"
+    "octgn": "17ed9b53-19f5-4ad1-ab91-14c2859e5a60",
+    "categories": "Resource Smoothing"
   },
   {
     "name": "Erkenbrand",
@@ -6956,7 +7135,8 @@
     "flavor": "Down from the hills leaped Erkenbrand, lord of Westfold. -The Two Towers",
     "textc": "Sentinel.\nWhile Erkenbrand is defending, he gains: `Response: Deal 1 damage to Erkenbrand to cancel a shadow effect just triggered.`",
     "name_norm": "Erkenbrand",
-    "octgn": "f2a282eb-eab1-472d-b7fb-71429a1a4855"
+    "octgn": "f2a282eb-eab1-472d-b7fb-71429a1a4855",
+    "categories": "Shadow Control"
   },
   {
     "name": "Warden of Helm's Deep",
@@ -6978,7 +7158,8 @@
     "flavor": "They now learned to their joy that Erkenbrand had left many men to hold Helm's Gate, and more had since escaped thither. -The Two Towers",
     "textc": "Sentinel.\n",
     "name_norm": "Warden of Helm's Deep",
-    "octgn": "f64befcc-d4de-47a4-8517-5f2617984270"
+    "octgn": "f64befcc-d4de-47a4-8517-5f2617984270",
+    "categories": ""
   },
   {
     "name": "The Day's Rising",
@@ -6993,10 +7174,11 @@
     "traits": " Song.",
     "keywords": "",
     "text": "Attach to a hero with sentinel.\nResponse: After attached hero defends against an attack and takes no damage while defending that attack, exhaust Day's Rising to add 1 resource to the attached hero's resource pool.",
-    "flavor": "Out of doubt, out of dark to the day's rising\r\nI came singing in the sun, sword unsheathing.\r\n-Éomer, The Return of the King",
+    "flavor": "Out of doubt, out of dark to the day's rising\nI came singing in the sun, sword unsheathing.\n-\u00c9omer, The Return of the King",
     "textc": "Attach to a hero with sentinel.\nResponse: After attached hero defends against an attack and takes no damage while defending that attack, exhaust Day's Rising to add 1 resource to the attached hero's resource pool.",
     "name_norm": "The Day's Rising",
-    "octgn": "5d1c8757-7409-41da-9e12-454af06e8946"
+    "octgn": "5d1c8757-7409-41da-9e12-454af06e8946",
+    "categories": "Resource Acceleration"
   },
   {
     "name": "Captain of Gondor",
@@ -7014,7 +7196,8 @@
     "flavor": "`Boromir it was that drove the enemy at last back from this western shore...` -Beregond, The Return of the King",
     "textc": "Attach to a Warrior hero.\nResponse: After you optionally engage an enemy, exhaust Captain of Gondor to give attached hero +1 Attack and +1 Defense until the end of the round.",
     "name_norm": "Captain of Gondor",
-    "octgn": "29b76593-0ef3-410b-aa85-1c282d4b1582"
+    "octgn": "29b76593-0ef3-410b-aa85-1c282d4b1582",
+    "categories": "Attack Bonus, Defense Bonus"
   },
   {
     "name": "Booming Ent",
@@ -7036,7 +7219,8 @@
     "flavor": "`...a man that hacks once at an Ent never gets a chance of a second blow.` -Merry, The Two Towers",
     "textc": "Cannot have restricted attachments. Enters play exhausted.\nBooming Ent gets +1 Attack for each damaged Ent character you control.",
     "name_norm": "Booming Ent",
-    "octgn": "665b16ad-accf-45c9-8725-f3f5d0818310"
+    "octgn": "665b16ad-accf-45c9-8725-f3f5d0818310",
+    "categories": "Attack Bonus"
   },
   {
     "name": "Ride Them Down",
@@ -7054,7 +7238,8 @@
     "flavor": "Like thunder they broke upon the enemy... -The Return of the King",
     "textc": "Quest Action: Choose a non-unique enemy in the staging area. Until the end of the phase, progress that would be placed on the quest from questing successfully is instead assigned as damage to the chosen enemy. (Progress must still be placed on any active location first.)",
     "name_norm": "Ride Them Down",
-    "octgn": "6461b502-cb47-4528-b18a-db45988f1692"
+    "octgn": "6461b502-cb47-4528-b18a-db45988f1692",
+    "categories": "Direct Damage"
   },
   {
     "name": "Shadows Give Way",
@@ -7072,7 +7257,8 @@
     "flavor": "At that moment he caught a flash of white and silver coming from the North, like a small star down on the dusky fields. -The Return of the King",
     "textc": "You must use resources from 3 different heroes' pools to pay for this card.\nAction: Discard each shadow card from each enemy in play.",
     "name_norm": "Shadows Give Way",
-    "octgn": "7c7912dc-4d55-4c40-98a0-befbbff24c90"
+    "octgn": "7c7912dc-4d55-4c40-98a0-befbbff24c90",
+    "categories": "Shadow Control"
   },
   {
     "name": "Don't Be Hasty!",
@@ -7090,7 +7276,8 @@
     "flavor": "`Don't be hasty, that is my motto.` -Treebeard, The Two Towers",
     "textc": "Response: When an encounter card is revealed but before resolving any of that card's keywords or `when revealed` effects, choose a character comited to the quest. Ready that character and remove it from the quest.",
     "name_norm": "Don't Be Hasty",
-    "octgn": "31406925-1626-4c17-b3ee-2e2700a99c14"
+    "octgn": "31406925-1626-4c17-b3ee-2e2700a99c14",
+    "categories": "Readying"
   },
   {
     "name": "Waters of Nimrodel",
@@ -7108,7 +7295,8 @@
     "flavor": "For a moment Frodo stood near the brink and let the water flow over his tired feet. It was cold but its touch was clean, and as he went on and it mounted to his knees, he felt that the strain of travel and all weariness was washed from his limbs. -The Fellowship of the Ring",
     "textc": "Doomed 3.\nAction: Heal all damage on each character in play.",
     "name_norm": "Waters of Nimrodel",
-    "octgn": "79cb32f4-053c-47e1-983d-59d64b493a76"
+    "octgn": "79cb32f4-053c-47e1-983d-59d64b493a76",
+    "categories": "Healing"
   },
   {
     "name": "Treebeard",
@@ -7127,10 +7315,10 @@
     "traits": " Ent.",
     "keywords": "",
     "text": "Cannot have restricted attachments. Treebeard enters play exhausted and collects 1 resource each resource phase. These resources can be used to pay for Ent cards played from your hand.\nAction: Pay 2 resources from Treebeard's pool to ready an Ent character.",
-    "flavor": null,
     "textc": "Cannot have restricted attachments. Treebeard enters play exhausted and collects 1 resource each resource phase. These resources can be used to pay for Ent cards played from your hand.\nAction: Pay 2 resources from Treebeard's pool to ready an Ent character.",
     "name_norm": "Treebeard",
-    "octgn": "c266126d-cf2d-4a61-aac7-28bac2d1ea0d"
+    "octgn": "c266126d-cf2d-4a61-aac7-28bac2d1ea0d",
+    "categories": "Readying"
   },
   {
     "name": "Aragorn",
@@ -7146,13 +7334,14 @@
     "no": 1,
     "img": "http://www.cardgamedb.com/forums/uploads/lotr/MEC38_1.jpg",
     "unique": true,
-    "traits": " Dúnedain. Ranger. Warrior.",
+    "traits": " D\u00fanedain. Ranger. Warrior.",
     "keywords": "",
     "text": "Each enemy engaged with you gets -1 Defense.\nResponse: After Aragorn participates in an attack that destroys an enemy, choose an enemy not engaged with you and engage that enemy.",
     "flavor": "`I serve no man,` said Aragorn; `but the servants of Sauron I pursue into whatever land they may go.` -The Two Towers",
     "textc": "Each enemy engaged with you gets -1 Defense.\nResponse: After Aragorn participates in an attack that destroys an enemy, choose an enemy not engaged with you and engage that enemy.",
     "name_norm": "Aragorn",
-    "octgn": "09ebd71c-8286-4838-b661-36a8633c9f0c"
+    "octgn": "09ebd71c-8286-4838-b661-36a8633c9f0c",
+    "categories": ""
   },
   {
     "name": "Halbarad",
@@ -7168,13 +7357,14 @@
     "no": 2,
     "img": "http://www.cardgamedb.com/forums/uploads/lotr/MEC38_2.jpg",
     "unique": true,
-    "traits": " Dúnedain. Ranger.",
+    "traits": " D\u00fanedain. Ranger.",
     "keywords": "",
     "text": "While you are engaged with any enemy, Halbarad does not exhaust to commit to a quest.\nYou may optionally engage 1 additional enemy during the encounter phase.",
     "flavor": "`Little do they know of our long labour for the safekeeping of their borders, and yet I grudge it not.` -The Return of the King",
     "textc": "While you are engaged with any enemy, Halbarad does not exhaust to commit to a quest.\nYou may optionally engage 1 additional enemy during the encounter phase.",
     "name_norm": "Halbarad",
-    "octgn": "52b151e9-f13b-4f85-961c-62838d25b97a"
+    "octgn": "52b151e9-f13b-4f85-961c-62838d25b97a",
+    "categories": ""
   },
   {
     "name": "Weather Hills Watchman",
@@ -7190,16 +7380,17 @@
     "no": 3,
     "img": "http://www.cardgamedb.com/forums/uploads/lotr/MEC38_3.jpg",
     "unique": false,
-    "traits": " Dúnedain.",
+    "traits": " D\u00fanedain.",
     "keywords": "",
     "text": "Response: After Weather Hills Watchman enters play, search the top 5 cards of your deck for a Signal card and add it to your hand. Shuffle the other cards back into your deck.",
     "flavor": "`Rangers use runes, and they come here sometimes.` -Aragorn, The Fellowship of the Ring",
     "textc": "Response: After Weather Hills Watchman enters play, search the top 5 cards of your deck for a Signal card and add it to your hand. Shuffle the other cards back into your deck.",
     "name_norm": "Weather Hills Watchman",
-    "octgn": "b313de3d-897e-4e74-afc5-d31fceaa6162"
+    "octgn": "b313de3d-897e-4e74-afc5-d31fceaa6162",
+    "categories": "Card Search"
   },
   {
-    "name": "Dúnedain Hunter",
+    "name": "D\u00fanedain Hunter",
     "type": "2ally",
     "sphere": "2tactics",
     "cost": 0,
@@ -7212,13 +7403,13 @@
     "no": 4,
     "img": "http://www.cardgamedb.com/forums/uploads/lotr/MEC38_4.jpg",
     "unique": false,
-    "traits": " Dúnedain. Ranger.",
+    "traits": " D\u00fanedain. Ranger.",
     "keywords": "",
-    "text": "Forced: After Dúnedain Hunter enters play, search the top 5 cards of the encounter deck for a non-unique enemy and put it into play engaged with you. If no enemy enters play by this effect, discard Dúnedain Hunter. Shuffle the encounter deck.",
-    "flavor": null,
-    "textc": "Forced: After Dúnedain Hunter enters play, search the top 5 cards of the encounter deck for a non-unique enemy and put it into play engaged with you. If no enemy enters play by this effect, discard Dúnedain Hunter. Shuffle the encounter deck.",
+    "text": "Forced: After D\u00fanedain Hunter enters play, search the top 5 cards of the encounter deck for a non-unique enemy and put it into play engaged with you. If no enemy enters play by this effect, discard D\u00fanedain Hunter. Shuffle the encounter deck.",
+    "textc": "Forced: After D\u00fanedain Hunter enters play, search the top 5 cards of the encounter deck for a non-unique enemy and put it into play engaged with you. If no enemy enters play by this effect, discard D\u00fanedain Hunter. Shuffle the encounter deck.",
     "name_norm": "Dunedain Hunter",
-    "octgn": "d15c0cc8-19c0-49d8-915f-c423e993c03b"
+    "octgn": "d15c0cc8-19c0-49d8-915f-c423e993c03b",
+    "categories": ""
   },
   {
     "name": "Sarn Ford Sentry",
@@ -7234,16 +7425,17 @@
     "no": 5,
     "img": "http://www.cardgamedb.com/forums/uploads/lotr/MEC38_5.jpg",
     "unique": false,
-    "traits": " Dúnedain. Scout.",
+    "traits": " D\u00fanedain. Scout.",
     "keywords": "",
     "text": "Response: After Sarn Ford Sentry enters play, draw 1 card for each enemy engaged with you.",
     "flavor": "`Lonely men are we, Rangers of the wild, hunters but hunters ever of the servants of the Enemy...` -Aragorn, The Fellowship of the Ring",
     "textc": "Response: After Sarn Ford Sentry enters play, draw 1 card for each enemy engaged with you.",
     "name_norm": "Sarn Ford Sentry",
-    "octgn": "2c6e85b4-18e3-4c21-95eb-5d74b9eebb5b"
+    "octgn": "2c6e85b4-18e3-4c21-95eb-5d74b9eebb5b",
+    "categories": "Card Draw"
   },
   {
-    "name": "Warden of Annúminas",
+    "name": "Warden of Ann\u00faminas",
     "type": "2ally",
     "sphere": "3spirit",
     "cost": 4,
@@ -7256,13 +7448,14 @@
     "no": 6,
     "img": "http://www.cardgamedb.com/forums/uploads/lotr/MEC38_6.jpg",
     "unique": false,
-    "traits": " Dúnedain. Ranger.",
+    "traits": " D\u00fanedain. Ranger.",
     "keywords": "",
-    "text": "Warden of Annúminas gets +1 Willpower for each enemy engaged with you.",
+    "text": "Warden of Ann\u00faminas gets +1 Willpower for each enemy engaged with you.",
     "flavor": "Rangers passed at times beyond the hills, but they were few and did not stay. -The Fellowship of the Ring",
-    "textc": "Warden of Annúminas gets +1 Willpower for each enemy engaged with you.",
+    "textc": "Warden of Ann\u00faminas gets +1 Willpower for each enemy engaged with you.",
     "name_norm": "Warden of Annuminas",
-    "octgn": "a933917f-4c7e-416e-8b08-ee2e60f6ab5f"
+    "octgn": "a933917f-4c7e-416e-8b08-ee2e60f6ab5f",
+    "categories": ""
   },
   {
     "name": "Ranger Summons",
@@ -7276,11 +7469,12 @@
     "unique": false,
     "traits": " Signal.",
     "keywords": "",
-    "text": "Play only if you control a Dúnedain hero.\nPlanning Action: Shuffle 1 of your set aside Ranger of the North allies with the encounter keyword into the encounter deck. Then, remove Ranger Summons from the game.",
+    "text": "Play only if you control a D\u00fanedain hero.\nPlanning Action: Shuffle 1 of your set aside Ranger of the North allies with the encounter keyword into the encounter deck. Then, remove Ranger Summons from the game.",
     "flavor": "`We rode as swiftly as we might when your summons came.` -Halbarad, The Return of the King",
-    "textc": "Play only if you control a Dúnedain hero.\nPlanning Action: Shuffle 1 of your set aside Ranger of the North allies with the encounter keyword into the encounter deck. Then, remove Ranger Summons from the game.",
+    "textc": "Play only if you control a D\u00fanedain hero.\nPlanning Action: Shuffle 1 of your set aside Ranger of the North allies with the encounter keyword into the encounter deck. Then, remove Ranger Summons from the game.",
     "name_norm": "Ranger Summons",
-    "octgn": "687c526e-85b5-47e3-b596-37148772c013"
+    "octgn": "687c526e-85b5-47e3-b596-37148772c013",
+    "categories": ""
   },
   {
     "name": "Tireless Hunters",
@@ -7298,7 +7492,8 @@
     "flavor": "`Many evil things there are that your strong walls and bright swords do not stay.` -Aragorn, The Fellowship of the Ring",
     "textc": "Play only before the resolving enemy attacks step.\nCombat Action: Choose an enemy not engaged with you. Engage that enemy. Then, discard a shadow card from that enemy, if able.",
     "name_norm": "Tireless Hunters",
-    "octgn": "cda0276f-d412-47f6-aecf-02ae8dc64c9a"
+    "octgn": "cda0276f-d412-47f6-aecf-02ae8dc64c9a",
+    "categories": "Shadow Control"
   },
   {
     "name": "Expert Trackers",
@@ -7316,7 +7511,8 @@
     "flavor": "`At last!` said Aragorn. `Here are the tracks that we seek!` -The Two Towers",
     "textc": "Response: After you engage an enemy, exhaust a Scout or Ranger character to place X progress tokens on a location. X is the engaged enemy's printed Threat.",
     "name_norm": "Expert Trackers",
-    "octgn": "86583668-7581-4bca-ba10-a4752878740e"
+    "octgn": "86583668-7581-4bca-ba10-a4752878740e",
+    "categories": ""
   },
   {
     "name": "Heir of Valandil",
@@ -7330,11 +7526,12 @@
     "unique": true,
     "traits": " Title.",
     "keywords": "",
-    "text": "Attach to a Dúnedain hero.\nPlanning Action: Exhaust Heir of Valandil to reduce the cost of the next Dúnedain ally you play this phase by 1 for each enemy engaged with you.",
+    "text": "Attach to a D\u00fanedain hero.\nPlanning Action: Exhaust Heir of Valandil to reduce the cost of the next D\u00fanedain ally you play this phase by 1 for each enemy engaged with you.",
     "flavor": "`But my home, such as I have, is in the North. For here the heirs of Valandil have ever dwelt in long line unbroken from father unto son for many generations.` -Aragorn, The Fellowship of the Ring",
-    "textc": "Attach to a Dúnedain hero.\nPlanning Action: Exhaust Heir of Valandil to reduce the cost of the next Dúnedain ally you play this phase by 1 for each enemy engaged with you.",
+    "textc": "Attach to a D\u00fanedain hero.\nPlanning Action: Exhaust Heir of Valandil to reduce the cost of the next D\u00fanedain ally you play this phase by 1 for each enemy engaged with you.",
     "name_norm": "Heir of Valandil",
-    "octgn": "8b9da56f-6713-457f-8f73-6fdc8168348f"
+    "octgn": "8b9da56f-6713-457f-8f73-6fdc8168348f",
+    "categories": ""
   },
   {
     "name": "Athelas",
@@ -7348,11 +7545,12 @@
     "unique": false,
     "traits": " Item.",
     "keywords": "",
-    "text": "Attach to a Dúnedain or Healer character.\nAction: Discard Athelas and exhaust attached character to heal all damage on a character. You may discard a Condition attachment from that character.",
+    "text": "Attach to a D\u00fanedain or Healer character.\nAction: Discard Athelas and exhaust attached character to heal all damage on a character. You may discard a Condition attachment from that character.",
     "flavor": "`...it is a healing plant that the Men of the West brought to Middle-earth. Athelas they named it...` -Aragorn, The Fellowship of the Ring",
-    "textc": "Attach to a Dúnedain or Healer character.\nAction: Discard Athelas and exhaust attached character to heal all damage on a character. You may discard a Condition attachment from that character.",
+    "textc": "Attach to a D\u00fanedain or Healer character.\nAction: Discard Athelas and exhaust attached character to heal all damage on a character. You may discard a Condition attachment from that character.",
     "name_norm": "Athelas",
-    "octgn": "7b1fb1e7-481d-4a14-85b1-d5d2c60087b6"
+    "octgn": "7b1fb1e7-481d-4a14-85b1-d5d2c60087b6",
+    "categories": "Condition Control, Healing"
   },
   {
     "name": "Secret Vigil",
@@ -7370,7 +7568,8 @@
     "flavor": "`If simple folk are free from care and fear, simple they will be, and we must be secret to keep them so.` -Aragorn, The Fellowship of the Ring",
     "textc": "Attach to an enemy. Limit 1 per enemy.\nAttached enemy gets -1 Threat.\nResponse: When attached enemy is destroyed, reduce each player's threat by the attached enemy's printed Threat.",
     "name_norm": "Secret Vigil",
-    "octgn": "7a8a2dbe-5a97-42da-a3c9-283724783145"
+    "octgn": "7a8a2dbe-5a97-42da-a3c9-283724783145",
+    "categories": "Threat Control"
   },
   {
     "name": "Star Brooch",
@@ -7384,22 +7583,23 @@
     "unique": false,
     "traits": " Item.",
     "keywords": "",
-    "text": "Attach to a Dúnedain or Noldor hero. Limit 1 per hero.\nWhile you are engaged with an enemy, attached hero gets +1 Willpower and cannot have its Willpower reduced.",
+    "text": "Attach to a D\u00fanedain or Noldor hero. Limit 1 per hero.\nWhile you are engaged with an enemy, attached hero gets +1 Willpower and cannot have its Willpower reduced.",
     "flavor": "...each cloak was pinned upon the left shoulder by a brooch of silver shaped like a rayed star. -The Return of the King",
-    "textc": "Attach to a Dúnedain or Noldor hero. Limit 1 per hero.\nWhile you are engaged with an enemy, attached hero gets +1 Willpower and cannot have its Willpower reduced.",
+    "textc": "Attach to a D\u00fanedain or Noldor hero. Limit 1 per hero.\nWhile you are engaged with an enemy, attached hero gets +1 Willpower and cannot have its Willpower reduced.",
     "name_norm": "Star Brooch",
-    "octgn": "130df5c3-a050-4690-8dac-d1ae937a2e3c"
+    "octgn": "130df5c3-a050-4690-8dac-d1ae937a2e3c",
+    "categories": ""
   },
   {
     "name": "Gather Information",
     "type": "5quest",
     "sphere": "5neutral",
-    "restrict": true,
     "cost": 0,
     "cycle": 8,
     "exp": "tlr",
     "no": 14,
     "img": "http://www.cardgamedb.com/forums/uploads/lotr/MEC38_14.jpg",
+    "restrict": true,
     "unique": false,
     "traits": "",
     "keywords": "Victory 1.",
@@ -7407,13 +7607,14 @@
     "flavor": "Aragorn halted and examined the tracks closely. -The Tower Towers",
     "textc": "Victory 1.\nLimit 1 per deck.\nResponse: After this stage is defeated, each player may search his deck for 1 card and add it to his hand. Each player shuffles his deck.",
     "name_norm": "Gather Information",
-    "octgn": "128f940d-8a71-4a80-83c2-bdbc014d95c9"
+    "octgn": "128f940d-8a71-4a80-83c2-bdbc014d95c9",
+    "categories": ""
   },
   {
     "name": "(Ranger of the North)",
     "type": "2ally",
     "sphere": "5neutral",
-    "cost": "-",
+    "cost": 0,
     "willpower": 2,
     "strength": 2,
     "defense": 2,
@@ -7423,17 +7624,14 @@
     "no": 15,
     "img": "http://www.cardgamedb.com/forums/uploads/lotr/MEC38_15.jpg",
     "unique": false,
-    "traits": " Dúnedain. Ranger.",
+    "traits": " D\u00fanedain. Ranger.",
     "keywords": "Encounter. Surge. Ranged. Sentinel.",
     "text": "When Revealed: The first player chooses a player to take control of Ranger of the North. Then either deal 2 damage to an enemy or place 2 progress tokens on a location.",
-    "flavor": "",
     "textc": "Encounter. Surge. Ranged. Sentinel.\nWhen Revealed: The first player chooses a player to take control of Ranger of the North. Then either deal 2 damage to an enemy or place 2 progress tokens on a location.",
     "name_norm": "ZZ_Ranger of the North",
-    "octgn": "156ed210-ab6e-4da9-b8c0-48984711edf2"
+    "octgn": "156ed210-ab6e-4da9-b8c0-48984711edf2",
+    "categories": "Direct Damage"
   },
-
-
-
   {
     "name": "Merry",
     "type": "1hero",
@@ -7454,7 +7652,8 @@
     "flavor": "`We have come a long way with you and been through some stiff times. We want to go on.` -The Fellowship of the Ring",
     "textc": "Response: After an enemy is revealed from the top of the encounter deck, exhaust Merry to reduce your threat by that enemy's Threat.",
     "name_norm": "Merry",
-    "octgn": "03a7152b-e6af-4aaf-a064-7e814fc181d5"
+    "octgn": "03a7152b-e6af-4aaf-a064-7e814fc181d5",
+    "categories": "Readying, Threat Control"
   },
   {
     "name": "Ingold",
@@ -7476,7 +7675,8 @@
     "flavor": "`We wist for no strangers in the land at this time, unless they be mighty men of arms in whose faith and help we can trust.` -The Return of the King",
     "textc": "Ingold gets +1 Willpower for each hero you control with at least 1 resource in its resource pool.",
     "name_norm": "Ingold",
-    "octgn": "1e28318c-e82a-4d50-b6db-d08e6e9a6b53"
+    "octgn": "1e28318c-e82a-4d50-b6db-d08e6e9a6b53",
+    "categories": ""
   },
   {
     "name": "Rallying Cry",
@@ -7494,7 +7694,8 @@
     "flavor": "He let blow the horns to rally all men to his banner that could come thither... -The Return of the King",
     "textc": "Response: After an ally leaves play, add it to its owner's hand instead of placing it in the discard pile.\nValour Action: Until the end of the phase, add each ally that leaves play to its owner's hand instead of placing it in the discard pile.",
     "name_norm": "Rallying Cry",
-    "octgn": "1c6d209d-8ff3-4b81-a03f-e81e132e3b5e"
+    "octgn": "1c6d209d-8ff3-4b81-a03f-e81e132e3b5e",
+    "categories": ""
   },
   {
     "name": "Honour Guard",
@@ -7513,10 +7714,10 @@
     "traits": " Gondor. Warrior.",
     "keywords": "",
     "text": "Response: Exhaust Honour Guard to cancel the first point of damage just dealt to a character.\nValour Response: Exhaust and discard Honour Guard to cancel up to 5 damage just dealt to a character.",
-    "flavor": "",
     "textc": "Response: Exhaust Honour Guard to cancel the first point of damage just dealt to a character.\nValour Response: Exhaust and discard Honour Guard to cancel up to 5 damage just dealt to a character",
     "name_norm": "Honour Guard",
-    "octgn": "7a8f5eb3-4c89-4516-974b-812b589cb818"
+    "octgn": "7a8f5eb3-4c89-4516-974b-812b589cb818",
+    "categories": ""
   },
   {
     "name": "Raven-winged Helm",
@@ -7534,7 +7735,8 @@
     "flavor": "He had a small hauberk, its rings forged of steel, maybe, yet black as jet; and a high-crowned helm with small raven-wings on either side, set with a silver star in the centre of the circlet. -The Return of the King",
     "textc": "Attach to a hero with sentinel. Limit 1 per hero.\nResponse: Exhaust Raven-winged Helm to cancel 1 point of damage just dealt to attached character.",
     "name_norm": "Raven-winged Helm",
-    "octgn": "62dd5a22-ccf4-4612-be1f-ea13d7da3ced"
+    "octgn": "62dd5a22-ccf4-4612-be1f-ea13d7da3ced",
+    "categories": ""
   },
   {
     "name": "Curious Brandybuck",
@@ -7553,10 +7755,10 @@
     "traits": " Hobbit.",
     "keywords": "",
     "text": "Forced: After the active location is explored, place Curious Brandybuck on the bottom of its owner's deck.\nResponse: After you travel to a location, put Curious Brandybuck into play from your hand, under any player's control.",
-    "flavor": "",
     "textc": "Forced: After the active location is explored, place Curious Brandybuck on the bottom of its owner's deck.\nResponse: After you travel to a location, put Curious Brandybuck into play from your hand, under any player's control.",
     "name_norm": "Curious Brandybuck",
-    "octgn": "c52c00b2-ab39-4ffa-898d-ab9c8246bd00"
+    "octgn": "c52c00b2-ab39-4ffa-898d-ab9c8246bd00",
+    "categories": ""
   },
   {
     "name": "Hobbit Pony",
@@ -7574,7 +7776,8 @@
     "flavor": "He was riding a pony, and a scarf was swathed round his neck and over his chin to keep out the fog. -The Fwllowship of the Ring.",
     "textc": "Attach to a Hobbit hero. Restricted.\nQuest Action: If attached hero is not committed to the quest, exhaust Hobbit Pony and attached hero to commit attached hero to the quest.",
     "name_norm": "Hobbit Pony",
-    "octgn": "ebcb133a-1777-49cf-a7d4-137a65b2c2d5"
+    "octgn": "ebcb133a-1777-49cf-a7d4-137a65b2c2d5",
+    "categories": ""
   },
   {
     "name": "East Road Ranger",
@@ -7590,13 +7793,14 @@
     "no": 8,
     "img": "http://www.cardgamedb.com/forums/uploads/lotr/MEC39_8.jpg",
     "unique": false,
-    "traits": " Dúnedain. Scout.",
+    "traits": " D\u00fanedain. Scout.",
     "keywords": "",
     "text": "East Road Ranger gets +2 Willpower while committed to a side quest.",
     "flavor": "`If you bring a Ranger with you, it is well to pay attention to him...` -Gandalf, the Fellowship of the Ring",
     "textc": "East Road Ranger gets +2 Willpower while committed to a side quest.",
     "name_norm": "East Road Ranger",
-    "octgn": "8b95d0c6-eda4-4820-8279-6bdddae7b499"
+    "octgn": "8b95d0c6-eda4-4820-8279-6bdddae7b499",
+    "categories": ""
   },
   {
     "name": "Scout Ahead",
@@ -7615,7 +7819,8 @@
     "flavor": "Strider made them take cover in a thicket at the side of the Road, while he went forward to explore. -The Fellowship of the Ring",
     "textc": "Victory 1.\nLimit 1 per deck.\nResponse: When this stage is defeated, the first player searches the top X cards of the encounter deck for 1 non-objective card worth no victory points and adds it to the victory display. Put the remaining cards back in any order. X is the number of players in the game plus 4.",
     "name_norm": "Scout Ahead",
-    "octgn": "f8a3acfb-3b0d-414b-b5d0-2612d33c193d"
+    "octgn": "f8a3acfb-3b0d-414b-b5d0-2612d33c193d",
+    "categories": ""
   },
   {
     "name": "Ranger of Cardolan",
@@ -7631,19 +7836,14 @@
     "no": 10,
     "img": "http://www.cardgamedb.com/forums/uploads/lotr/MEC39_10.jpg",
     "unique": false,
-    "traits": " Dúnedain. Ranger.",
+    "traits": " D\u00fanedain. Ranger.",
     "keywords": "",
-    "text": "Response: After you engage an enemy, if you control at least 1 Dúnedain hero, spend 1 resource to put Ranger of Cardolan into play from your hand, under your control. At the end of the round, if Ranger of Cardolan is still in play, shuffle it into its owner's deck.",
-    "flavor": "",
-    "textc": "Response: After you engage an enemy, if you control at least 1 Dúnedain hero, spend 1 resource to put Ranger of Cardolan into play from your hand, under your control. At the end of the round, if Ranger of Cardolan is still in play, shuffle it into its owner's deck.",
+    "text": "Response: After you engage an enemy, if you control at least 1 D\u00fanedain hero, spend 1 resource to put Ranger of Cardolan into play from your hand, under your control. At the end of the round, if Ranger of Cardolan is still in play, shuffle it into its owner's deck.",
+    "textc": "Response: After you engage an enemy, if you control at least 1 D\u00fanedain hero, spend 1 resource to put Ranger of Cardolan into play from your hand, under your control. At the end of the round, if Ranger of Cardolan is still in play, shuffle it into its owner's deck.",
     "name_norm": "Ranger of Cardolan",
-    "octgn": "cc73532b-e891-49b6-9544-468b5977149a"
+    "octgn": "cc73532b-e891-49b6-9544-468b5977149a",
+    "categories": ""
   },
-
-
-
-
-
   {
     "name": "Rossiel",
     "type": "1hero",
@@ -7664,7 +7864,8 @@
     "flavor": "`Did you not say that you wished to see Elf-magic?` -Galadriel, The Fellowship of the Ring",
     "textc": "If the active location shares a Trait with a location in the victory display, Rossiel gets +2 Willpower.\n If the attacking enemy shares a Trait with an enemy in the victory display, Rossiel gets +2 Defense.",
     "name_norm": "Rossiel",
-    "octgn": "18fea279-cd38-4a5e-b271-b94d4f64eda1"
+    "octgn": "18fea279-cd38-4a5e-b271-b94d4f64eda1",
+    "categories": "Defense Bonus"
   },
   {
     "name": "Veteran of Osgiliath",
@@ -7686,7 +7887,8 @@
     "flavor": "`So do we ever watch the shores nigh Osgiliath, which our enemies now partly hold, and issue from it to harry our lands.` -Faramir, The Two Towers",
     "textc": "Veteran of Osgiliath gets +1 Willpower, +1 Attack, and +1 Defense while your threat is 40 or higher.",
     "name_norm": "Veteran of Osgiliath",
-    "octgn": "0484e428-6a72-4841-b2d5-d8df7cfb51bf"
+    "octgn": "0484e428-6a72-4841-b2d5-d8df7cfb51bf",
+    "categories": "Defense Bonus"
   },
   {
     "name": "Descendants of Kings",
@@ -7700,11 +7902,12 @@
     "unique": false,
     "traits": "",
     "keywords": "",
-    "text": "Action: Ready up to X Dúnedain characters you control. X is the number of enemies engaged with you.",
+    "text": "Action: Ready up to X D\u00fanedain characters you control. X is the number of enemies engaged with you.",
     "flavor": "`But when dark things come from the houseless hills, or creep from sunless woods, they fly from us.` -Aragorn, The Fellowship of the Ring",
-    "textc": "Action: Ready up to X Dúnedain characters you control. X is the number of enemies engaged with you.",
+    "textc": "Action: Ready up to X D\u00fanedain characters you control. X is the number of enemies engaged with you.",
     "name_norm": "Descendants of Kings",
-    "octgn": "25641d97-e196-40d5-8481-727602aa2da2"
+    "octgn": "25641d97-e196-40d5-8481-727602aa2da2",
+    "categories": "Readying"
   },
   {
     "name": "Derndingle Warrior",
@@ -7723,10 +7926,10 @@
     "traits": " Ent.",
     "keywords": "Sentinel.",
     "text": "Cannot have restricted attachments.\nEnters play exhausted.\nWhile Derndingle Warrior is defending, it gains: `Action: Deal 1 damage to Derndingle Warrior to give it +3 Defense for this attack.` (Limit once per attack.)",
-    "flavor": "",
     "textc": "Sentinel.\nCannot have restricted attachments.\nEnters play exhausted.\nWhile Derndingle Warrior is defending, it gains: `Action: Deal 1 damage to Derndingle Warrior to give it +3 Defense for this attack.` (Limit once per attack.)",
     "name_norm": "Derndingle Warrior",
-    "octgn": "e562d744-bf7d-4325-97ba-424bf3ca3ca8"
+    "octgn": "e562d744-bf7d-4325-97ba-424bf3ca3ca8",
+    "categories": "Direct Damage, Defense Bonus"
   },
   {
     "name": "Boomed and Trumpeted",
@@ -7744,7 +7947,8 @@
     "flavor": "`They roared and boomed and trumpeted, until stones began to crack and fall at the mere noise of them.` -Merry, The Two Towers",
     "textc": "Response: After an Ent character takes any amount of damage, ready it. That character gets +3 Attack until the end of the phase.",
     "name_norm": "Boomed and Trumpeted",
-    "octgn": "f4b2af17-b589-49c1-a884-ecd4570d8545"
+    "octgn": "f4b2af17-b589-49c1-a884-ecd4570d8545",
+    "categories": "Attack Bonus, Readying"
   },
   {
     "name": "Elven Jeweler",
@@ -7766,7 +7970,8 @@
     "flavor": "`...to the Elven-smiths they were but trifles...` -Gandalf, The Fellowship of the Ring",
     "textc": "Action: Discard 2 cards from your hand to put Elven Jeweler into play from your hand, under your control.",
     "name_norm": "Elven Jeweler",
-    "octgn": "9c42d496-267e-4822-8df4-6fcc7ae4c2d1"
+    "octgn": "9c42d496-267e-4822-8df4-6fcc7ae4c2d1",
+    "categories": ""
   },
   {
     "name": "Double Back",
@@ -7777,15 +7982,16 @@
     "exp": "efmg",
     "no": 34,
     "img": "http://www.cardgamedb.com/forums/uploads/lotr/MEC40_34.jpg",
-    "unique": false,
     "restrict": true,
+    "unique": false,
     "traits": "",
     "keywords": "",
-    "text": "Limit 1 per deck.\nResponse: When this stage is defeated, reduce each player’s threat by 5.",
+    "text": "Limit 1 per deck.\nResponse: When this stage is defeated, reduce each player\u2019s threat by 5.",
     "flavor": "He was taking a wandering course with many turns and doublings, to put off any pursuit. -The Fellowship of the Ring",
-    "textc": "Limit 1 per deck.\nResponse: When this stage is defeated, reduce each player’s threat by 5.",
+    "textc": "Limit 1 per deck.\nResponse: When this stage is defeated, reduce each player\u2019s threat by 5.",
     "name_norm": "Double Back",
-    "octgn": "f4d94f3d-d3af-44d6-9896-764484302bb1"
+    "octgn": "f4d94f3d-d3af-44d6-9896-764484302bb1",
+    "categories": ""
   },
   {
     "name": "Leave No Trace",
@@ -7800,10 +8006,10 @@
     "traits": "",
     "keywords": "",
     "text": "Limit 3 copies of Leave No Trace in the victory display.\nResponse: After a non-unique location is explored, add Leave No Trace to the victory display to add that location to the victory display.",
-    "flavor": "",
     "textc": "Limit 3 copies of Leave No Trace in the victory display.\nResponse: After a non-unique location is explored, add Leave No Trace to the victory display to add that location to the victory display.",
     "name_norm": "Leave No Trace",
-    "octgn": "57658f13-fb9c-4a87-bb05-965a022cc69d"
+    "octgn": "57658f13-fb9c-4a87-bb05-965a022cc69d",
+    "categories": ""
   },
   {
     "name": "Distant Stars",
@@ -7818,10 +8024,11 @@
     "traits": "",
     "keywords": "",
     "text": "Action: Exhaust a Ranger or Scout character to discard a non-unique active location. Then, search the encounter deck and discard pile for a non-unique location and make it the active location. Shuffle the encounter deck.",
-    "flavor": "`I have crossed many mountains and many rivers, and trodden many plains, even into the far countries of Rhûn and Harad where the stars are strange...` -Aragorn, The Fellowship of the Ring",
+    "flavor": "`I have crossed many mountains and many rivers, and trodden many plains, even into the far countries of Rh\u00fbn and Harad where the stars are strange...` -Aragorn, The Fellowship of the Ring",
     "textc": "Action: Exhaust a Ranger or Scout character to discard a non-unique active location. Then, search the encounter deck and discard pile for a non-unique location and make it the active location. Shuffle the encounter deck.",
     "name_norm": "Distant Stars",
-    "octgn": "3ba15db9-9967-48b8-9b38-4fdfb4866676"
+    "octgn": "3ba15db9-9967-48b8-9b38-4fdfb4866676",
+    "categories": ""
   },
   {
     "name": "Keen as Lances",
@@ -7836,15 +8043,11 @@
     "traits": "",
     "keywords": "",
     "text": "Reduce the cost to play Keen as Lances by 1 for each card worth no victory points in the victory display.\nAction: Add Keen as Lances to the victory display. Then, choose one: add 2 resources to a hero's resource pool, draw 3 cards, or reduce your threat by 4.",
-    "flavor": "",
     "textc": "Reduce the cost to play Keen as Lances by 1 for each card worth no victory points in the victory display.\nAction: Add Keen as Lances to the victory display. Then, choose one: add 2 resources to a hero's resource pool, draw 3 cards, or reduce your threat by 4.",
     "name_norm": "Keen as Lances",
-    "octgn": "ede00b4b-15e0-4469-aaf6-ea60c9376898"
+    "octgn": "ede00b4b-15e0-4469-aaf6-ea60c9376898",
+    "categories": "Card Draw, Resource Acceleration, Threat Control"
   },
-
-
-
-
   {
     "name": "Dori",
     "type": "1hero",
@@ -7865,7 +8068,8 @@
     "flavor": "Dore was really a decent fellow in spite of his grumbling. -The Hobbit",
     "textc": "Sentinel.\nResponse: After another hero is declared as a defender, exhaust Dori to add his Defense to the defending hero's Defense for this attack.",
     "name_norm": "Dori",
-    "octgn": "a25c47a4-3a9c-4883-a7a7-c40df596650c"
+    "octgn": "a25c47a4-3a9c-4883-a7a7-c40df596650c",
+    "categories": ""
   },
   {
     "name": "Ranger Provisions",
@@ -7883,10 +8087,11 @@
     "flavor": "`Ranger have been here lately. It is they who left the firewood behind.` -Aragorn, The Fellowship of the Ring",
     "textc": "Attach to a location. Limit 1 per location.\nResponse: After attached location is explored, the first player adds 1 resource to each of his heroes' resource pools.",
     "name_norm": "Ranger Provisions",
-    "octgn": "265b6ab0-446c-4090-a7e1-341ce987c903"
+    "octgn": "265b6ab0-446c-4090-a7e1-341ce987c903",
+    "categories": ""
   },
   {
-    "name": "Dúnedain Message",
+    "name": "D\u00fanedain Message",
     "type": "4event",
     "sphere": "1leadership",
     "cost": 1,
@@ -7898,10 +8103,11 @@
     "traits": " Signal.",
     "keywords": "",
     "text": "Action: Search your deck for a side quest and add it to your hand. Shuffle your deck.",
-    "flavor": "`I called for the help of the Dúnedain, and their watch was doubled...` -Gandalf, The Fellowship of the Ring",
+    "flavor": "`I called for the help of the D\u00fanedain, and their watch was doubled...` -Gandalf, The Fellowship of the Ring",
     "textc": "Action: Search your deck for a side quest and add it to your hand. Shuffle your deck.",
     "name_norm": "Dunedain Message",
-    "octgn": "d54a293d-7e36-4dab-98e9-71fa23df2355"
+    "octgn": "d54a293d-7e36-4dab-98e9-71fa23df2355",
+    "categories": "Card Search"
   },
   {
     "name": "Longbeard Sentry",
@@ -7923,7 +8129,8 @@
     "flavor": "`...many of them have had experience in the dreadful dwarf and goblin wars, of which you have no doubt heard.` -Bilbo Baggins, The Hobbit",
     "textc": "Action: Discard 2 cards from the top of your deck to give Longbeard Sentry sentinel and +1 Defense until the end of the phase. (Limit once per phase.)",
     "name_norm": "Longbeard Sentry",
-    "octgn": "54b219c4-a359-435f-9988-336cad0384b2"
+    "octgn": "54b219c4-a359-435f-9988-336cad0384b2",
+    "categories": "Defense Bonus"
   },
   {
     "name": "Delay the Enemy",
@@ -7935,13 +8142,14 @@
     "no": 58,
     "img": "http://www.cardgamedb.com/forums/uploads/lotr/MEC41_58.jpg",
     "restrict": true,
+    "unique": "",
     "traits": "",
     "keywords": "Battle.",
     "text": "Response: When this stage is defeated, each player may choose and discard a non-unique enemy engaged with him.",
-    "flavor": "",
     "textc": "Limit 1 per deck.\nBattle. (Characters use their Attack instead of Willpower when questing here.)\nResponse: When this stage is defeated, each player may choose and discard a non-unique enemy engaged with him.",
     "name_norm": "Delay the Enemy",
-    "octgn": "b11ff1d9-c9e9-4cc1-b329-8226b73dd429"
+    "octgn": "b11ff1d9-c9e9-4cc1-b329-8226b73dd429",
+    "categories": ""
   },
   {
     "name": "Steed of Imladris",
@@ -7959,7 +8167,8 @@
     "flavor": "In the dusk its headstall flickered and flashed, as if it were studded with gems like living stars -The Fellowship of the Ring",
     "textc": "Attach to a Spirit or Noldor hero. Restricted.\nResponse: After attached hero commits to a quest, discard a card from your hand to place 2 progress on the active location.",
     "name_norm": "Steed of Imladris",
-    "octgn": "8741c7a7-be7d-462a-b39a-0c9bfe4042a3"
+    "octgn": "8741c7a7-be7d-462a-b39a-0c9bfe4042a3",
+    "categories": ""
   },
   {
     "name": "Fair and Perilous",
@@ -7977,7 +8186,8 @@
     "flavor": "`...you saw him for a moment as he is upon the other side: one of the mighty of the Firstborn.` -Gandalf, The Fellowship of the Ring",
     "textc": "Action: Choose a Noldor or Silvan character. Until the end of the phase, add that character's Willpower to its Attack.",
     "name_norm": "Fair and Perilous",
-    "octgn": "475d185f-403f-4b3e-9e8b-6b9f539c2423"
+    "octgn": "475d185f-403f-4b3e-9e8b-6b9f539c2423",
+    "categories": ""
   },
   {
     "name": "Wellinghall Preserver",
@@ -7996,10 +8206,10 @@
     "traits": " Ent.",
     "keywords": "",
     "text": "Cannot have restricted attachments.\nEnters play exhausted.\nResponse: After Wellinghall Preserver readies, heal 1 damage from an Ent character.",
-    "flavor": "",
     "textc": "Cannot have restricted attachments.\nEnters play exhausted.\nResponse: After Wellinghall Preserver readies, heal 1 damage from an Ent character.",
     "name_norm": "Wellinghall Preserver",
-    "octgn": "68a9d6cc-13a2-417a-ad87-f213ddc2bf48"
+    "octgn": "68a9d6cc-13a2-417a-ad87-f213ddc2bf48",
+    "categories": "Healing"
   },
   {
     "name": "None Return",
@@ -8014,10 +8224,11 @@
     "traits": "",
     "keywords": "",
     "text": "Limit 3 copies of None Return in the victory display.\nResponse: After a non-unique enemy is destroyed, add None Return to the victory display to add that enemy to the victory display.",
-    "flavor": "`None of the Orcs will ever return out of Lórien.` -Haldir, The Fellowship of the Ring",
+    "flavor": "`None of the Orcs will ever return out of L\u00f3rien.` -Haldir, The Fellowship of the Ring",
     "textc": "Limit 3 copies of None Return in the victory display.\nResponse: After a non-unique enemy is destroyed, add None Return to the victory display to add that enemy to the victory display.",
     "name_norm": "None Return",
-    "octgn": "6cf22f3e-29bd-4bbb-8459-92b7b4bc6b02"
+    "octgn": "6cf22f3e-29bd-4bbb-8459-92b7b4bc6b02",
+    "categories": ""
   },
   {
     "name": "Hope Rekindled",
@@ -8035,9 +8246,9 @@
     "flavor": "Hope he rekindled, and in hope ended;\nover death, over dread, over doom lifted\nOut of loss, out of life, unto long glory.\n-The Return of the King",
     "textc": "Action: Reduce the cost of the next event that has a Valour trigger you play this phase by 2.\nValour Action: Search the top 10 cards of your deck for an event that has a Valour trigger and add it to your hand. Shuffle your deck.",
     "name_norm": "Hope Rekindled",
-    "octgn": "809470ac-05c2-4578-9556-8c64b84d4619"
+    "octgn": "809470ac-05c2-4578-9556-8c64b84d4619",
+    "categories": "Card Search"
   },
-
   {
     "name": "Erestor",
     "type": "1hero",
@@ -8055,10 +8266,10 @@
     "traits": " Noldor.",
     "keywords": "",
     "text": "Draw 3 additional cards at the beginning of the resource phase. \nAt the end of the round, discard all cards in your hand.",
-    "flavor": "",
     "textc": "Draw 3 additional cards at the beginning of the resource phase. \nAt the end of the round, discard all cards in your hand.",
     "name_norm": "Erestor",
-    "octgn": "b188f729-0314-4664-95a0-7f93f4d44133"
+    "octgn": "b188f729-0314-4664-95a0-7f93f4d44133",
+    "categories": "Card Draw"
   },
   {
     "name": "Reinforcements",
@@ -8073,10 +8284,10 @@
     "traits": "",
     "keywords": "",
     "text": "You must spend resources from 3 different heroes' resource pools to play this card. \nAction: The players, as a group, can put up to 2 allies into play from their hands. Each of these allies may enter play under any player's control. At the end of the phase, return each of those allies that are still in play to their owners' hands.",
-    "flavor": "",
     "textc": "You must spend resources from 3 different heroes' resource pools to play this card. \nAction: The players, as a group, can put up to 2 allies into play from their hands. Each of these allies may enter play under any player's control. At the end of the phase, return each of those allies that are still in play to their owners' hands.",
     "name_norm": "Reinforcements",
-    "octgn": "b9339072-5665-45c7-a2ca-a8c844c5762d"
+    "octgn": "b9339072-5665-45c7-a2ca-a8c844c5762d",
+    "categories": ""
   },
   {
     "name": "Send for Aid",
@@ -8087,15 +8298,15 @@
     "exp": "ttor",
     "no": 86,
     "img": "http://www.cardgamedb.com/forums/uploads/lotr/MEC42_86.jpg",
-    "unique": false,
     "restrict": true,
+    "unique": false,
     "traits": "",
     "keywords": "",
     "text": "Limit 1 per deck. \nResponse: When this stage is defeated, each player may search the top 10 cards of his deck for an ally and put it into play under his control. Each player who did shuffles his deck.",
-    "flavor": "",
     "textc": "Limit 1 per deck. \nResponse: When this stage is defeated, each player may search the top 10 cards of his deck for an ally and put it into play under his control. Each player who did shuffles his deck.",
     "name_norm": "Send for Aid",
-    "octgn": "ad0cbc82-6807-4a5a-ada8-97952cb02c5f"
+    "octgn": "ad0cbc82-6807-4a5a-ada8-97952cb02c5f",
+    "categories": ""
   },
   {
     "name": "Elven Spear",
@@ -8110,10 +8321,10 @@
     "traits": " Item. Weapon.",
     "keywords": "Restricted.",
     "text": "Attach to a Noldor or Silvan hero. \nAction: Discard a card from your hand to give attached hero +1 Attack until the end of the phase. Limit 3 times per phase.",
-    "flavor": "",
     "textc": "Attach to a Noldor or Silvan hero. Restricted. \nAction: Discard a card from your hand to give attached hero +1 Attack until the end of the phase. Limit 3 times per phase.",
     "name_norm": "Elven Spear",
-    "octgn": "6ba569dd-92d4-4de4-bfa4-385e2d50eddb"
+    "octgn": "6ba569dd-92d4-4de4-bfa4-385e2d50eddb",
+    "categories": "Attack Bonus"
   },
   {
     "name": "Horn's Cry",
@@ -8128,10 +8339,10 @@
     "traits": "",
     "keywords": "",
     "text": "Action: All enemies get -1 Attack until the end of the phase. \nValour Action: Choose a player. Each enemy engaged with that player gets -3 Attack until the end of the phase.",
-    "flavor": "",
     "textc": "Action: All enemies get -1 Attack until the end of the phase. \nValour Action: Choose a player. Each enemy engaged with that player gets -3 Attack until the end of the phase.",
     "name_norm": "Horn's Cry",
-    "octgn": "7d906063-149f-4b7d-b271-e1532afea7c0"
+    "octgn": "7d906063-149f-4b7d-b271-e1532afea7c0",
+    "categories": ""
   },
   {
     "name": "Galadhrim Weaver",
@@ -8150,10 +8361,10 @@
     "traits": " Silvan. Craftsman.",
     "keywords": "",
     "text": "Cannot attack or defend. \nResponse: After Galadhrim Weaver enters play, shuffle the top card of your discard pile into your deck.",
-    "flavor": "",
     "textc": "Cannot attack or defend. \nResponse: After Galadhrim Weaver enters play, shuffle the top card of your discard pile into your deck.",
     "name_norm": "Galadhrim Weaver",
-    "octgn": "5ababdc3-8d6c-47ad-aa1a-d21f5c96bbda"
+    "octgn": "5ababdc3-8d6c-47ad-aa1a-d21f5c96bbda",
+    "categories": ""
   },
   {
     "name": "Silver Harp",
@@ -8168,10 +8379,10 @@
     "traits": " Item. Instrument.",
     "keywords": "Restricted.",
     "text": "Attach to a Spirit hero. \nResponse: After a card is discarded from your hand, exhaust Silver Harp to return that card to your hand.",
-    "flavor": "",
     "textc": "Attach to a Spirit hero. Restricted. \nResponse: After a card is discarded from your hand, exhaust Silver Harp to return that card to your hand.",
     "name_norm": "Silver Harp",
-    "octgn": "41b56fc4-6ecd-4c9a-80d4-3074c267e823"
+    "octgn": "41b56fc4-6ecd-4c9a-80d4-3074c267e823",
+    "categories": ""
   },
   {
     "name": "Galdor of the Havens",
@@ -8190,10 +8401,10 @@
     "traits": " Noldor.",
     "keywords": "",
     "text": "Response: After 1 or more cards are discarded from your hand, draw 1 card. Limit once per round.",
-    "flavor": "",
     "textc": "Response: After 1 or more cards are discarded from your hand, draw 1 card. Limit once per round.",
     "name_norm": "Galdor of the Havens",
-    "octgn": "608ac037-89dd-4aac-8b6d-057bd0fa7507"
+    "octgn": "608ac037-89dd-4aac-8b6d-057bd0fa7507",
+    "categories": "Card Draw"
   },
   {
     "name": "The Door is Closed!",
@@ -8208,10 +8419,10 @@
     "traits": "",
     "keywords": "",
     "text": "Response: After an encounter card is revealed from the encounter deck, cancel its effects and discard it if there is a card with the same title in the victory display.",
-    "flavor": "",
     "textc": "Response: After an encounter card is revealed from the encounter deck, cancel its effects and discard it if there is a card with the same title in the victory display.",
     "name_norm": "The Door is Closed",
-    "octgn": "f9f464e9-188c-42aa-bbea-b325a6d0f16d"
+    "octgn": "f9f464e9-188c-42aa-bbea-b325a6d0f16d",
+    "categories": ""
   },
   {
     "name": "Elf-friend",
@@ -8226,13 +8437,13 @@
     "traits": " Title.",
     "keywords": "",
     "text": "Attach to a character. Attached character gains the Noldor and Silvan traits.",
-    "flavor": "",
     "textc": "Attach to a character. Attached character gains the Noldor and Silvan traits.",
     "name_norm": "Elf-friend",
-    "octgn": "38ed7520-8749-47ab-b3b4-34ec96441475"
+    "octgn": "38ed7520-8749-47ab-b3b4-34ec96441475",
+    "categories": ""
   },
   {
-    "name": "Amarthiúl",
+    "name": "Amarthi\u00fal",
     "type": "1hero",
     "sphere": "1leadership",
     "cost": 10,
@@ -8245,13 +8456,13 @@
     "no": 115,
     "img": "http://www.cardgamedb.com/forums/uploads/lotr/MEC43_115.jpg",
     "unique": true,
-    "traits": " Dúnedain. Ranger. Warrior.",
+    "traits": " D\u00fanedain. Ranger. Warrior.",
     "keywords": "",
-    "text": "While you are engaged with at least 1 enemy, Amarthiúl gains the Tactics resource icon.\nWhile you are engaged with at least 2 enemies, add 1 additional resource to Amarthiúl's resource pool when you collect resources during the resource phase.",
-    "flavor": "",
-    "textc": "While you are engaged with at least 1 enemy, Amarthiúl gains the Tactics resource icon.\nWhile you are engaged with at least 2 enemies, add 1 additional resource to Amarthiúl's resource pool when you collect resources during the resource phase.",
+    "text": "While you are engaged with at least 1 enemy, Amarthi\u00fal gains the Tactics resource icon.\nWhile you are engaged with at least 2 enemies, add 1 additional resource to Amarthi\u00fal's resource pool when you collect resources during the resource phase.",
+    "textc": "While you are engaged with at least 1 enemy, Amarthi\u00fal gains the Tactics resource icon.\nWhile you are engaged with at least 2 enemies, add 1 additional resource to Amarthi\u00fal's resource pool when you collect resources during the resource phase.",
     "name_norm": "Amarthiul",
-    "octgn": "94726dff-4b95-4c7c-9542-320b45652d7a"
+    "octgn": "94726dff-4b95-4c7c-9542-320b45652d7a",
+    "categories": ""
   },
   {
     "name": "Guardian of Arnor",
@@ -8267,13 +8478,13 @@
     "no": 116,
     "img": "http://www.cardgamedb.com/forums/uploads/lotr/MEC43_116.jpg",
     "unique": false,
-    "traits": " Dúnedain. Ranger.",
+    "traits": " D\u00fanedain. Ranger.",
     "keywords": "Sentinel.",
     "text": "Guardian of Arnor gets +1 Defense for each enemy engaged with you.",
-    "flavor": "",
     "textc": "Sentinel.\nGuardian of Arnor gets +1 Defense for each enemy engaged with you.",
     "name_norm": "Guardian of Arnor",
-    "octgn": "0f2501c7-16ad-4fee-bea6-17b767fb0d14"
+    "octgn": "0f2501c7-16ad-4fee-bea6-17b767fb0d14",
+    "categories": "Defense Bonus"
   },
   {
     "name": "Doom Hangs Still",
@@ -8284,13 +8495,14 @@
     "exp": "tbocd",
     "no": 117,
     "img": "http://www.cardgamedb.com/forums/uploads/lotr/MEC43_117.jpg",
+    "unique": "",
     "traits": "",
     "keywords": "",
     "text": "Planning Action: Until the end of the round, players do not raise their threat from questing unsuccessfully.\nValour Planning Action: Raise each player's threat by 2 to skip the quest phase this round.",
-    "flavor": "",
     "textc": "Planning Action: Until the end of the round, players do not raise their threat from questing unsuccessfully.\nValour Planning Action: Raise each player's threat by 2 to skip the quest phase this round.",
     "name_norm": "Doom Hangs Still",
-    "octgn": "c48b1c7f-f3df-4e5c-ad63-a68efc66c02c"
+    "octgn": "c48b1c7f-f3df-4e5c-ad63-a68efc66c02c",
+    "categories": ""
   },
   {
     "name": "Beechbone",
@@ -8309,10 +8521,10 @@
     "traits": " Ent.",
     "keywords": "",
     "text": "Cannot have attachments. Enters play exhausted.\nResponse: After Beechbone is declared as an attacker, deal 1 damage to him to deal X damage to the defending enemy. X is the amount of damage on Beechbone.",
-    "flavor": "",
     "textc": "Cannot have attachments. Enters play exhausted.\nResponse: After Beechbone is declared as an attacker, deal 1 damage to him to deal X damage to the defending enemy. X is the amount of damage on Beechbone.",
     "name_norm": "Beechbone",
-    "octgn": "b1584166-c8b3-4984-bfdc-06c33f31e153"
+    "octgn": "b1584166-c8b3-4984-bfdc-06c33f31e153",
+    "categories": ""
   },
   {
     "name": "Hold Your Ground!",
@@ -8323,13 +8535,14 @@
     "exp": "tbocd",
     "no": 119,
     "img": "http://www.cardgamedb.com/forums/uploads/lotr/MEC43_119.jpg",
+    "unique": "",
     "traits": "",
     "keywords": "",
     "text": "Action: Choose and ready a sentinel character.\nValour Action: Ready all sentinel characters.",
-    "flavor": "",
     "textc": "Action: Choose and ready a sentinel character.\nValour Action: Ready all sentinel characters.",
     "name_norm": "Hold Your Ground",
-    "octgn": "8588e98f-1aaf-4e90-95b9-48b76c0fc4be"
+    "octgn": "8588e98f-1aaf-4e90-95b9-48b76c0fc4be",
+    "categories": "Readying"
   },
   {
     "name": "Lindir",
@@ -8348,10 +8561,10 @@
     "traits": " Noldor.",
     "keywords": "",
     "text": "Response: After Lindir enters play, if you have less than 3 cards in your hand, draw until you have 3 cards in your hand.",
-    "flavor": "",
     "textc": "Response: After Lindir enters play, if you have less than 3 cards in your hand, draw until you have 3 cards in your hand.",
     "name_norm": "Lindir",
-    "octgn": "4bff71e7-f66c-4a2d-ba7d-633a6c77f765"
+    "octgn": "4bff71e7-f66c-4a2d-ba7d-633a6c77f765",
+    "categories": ""
   },
   {
     "name": "Lords of the Eldar",
@@ -8362,13 +8575,14 @@
     "exp": "tbocd",
     "no": 121,
     "img": "http://www.cardgamedb.com/forums/uploads/lotr/MEC43_121.jpg",
+    "unique": "",
     "traits": "",
     "keywords": "",
     "text": "Lords of the Eldar can only be played from your discard pile.\nAction: Place Lords of the Eldar on the bottom of your deck from your discard pile. Then, until the end of the round all Noldor characters get +1 Willpower, +1 Attack, and +1 Defense.",
-    "flavor": "",
     "textc": "Lords of the Eldar can only be played from your discard pile.\nAction: Place Lords of the Eldar on the bottom of your deck from your discard pile. Then, until the end of the round all Noldor characters get +1 Willpower, +1 Attack, and +1 Defense.",
     "name_norm": "Lords of the Eldar",
-    "octgn": "ff265d76-021b-4f23-9e62-a57e16b3e77d"
+    "octgn": "ff265d76-021b-4f23-9e62-a57e16b3e77d",
+    "categories": "Attack Bonus, Defense Bonus"
   },
   {
     "name": "The Long Defeat",
@@ -8379,13 +8593,14 @@
     "exp": "tbocd",
     "no": 122,
     "img": "http://www.cardgamedb.com/forums/uploads/lotr/MEC43_122.jpg",
+    "unique": "",
     "traits": " Condition.",
     "keywords": "",
     "text": "Attach to a quest card in play. Limit 1 per quest.\nResponse: After attached quest card is defeated, each player either draws 2 cards or heals up to 5 damage from among characters he controls.",
-    "flavor": "",
     "textc": "Attach to a quest card in play. Limit 1 per quest.\nResponse: After attached quest card is defeated, each player either draws 2 cards or heals up to 5 damage from among characters he controls.",
     "name_norm": "The Long Defeat",
-    "octgn": "0b483cda-22e0-418d-b906-8a93e94fe95d"
+    "octgn": "0b483cda-22e0-418d-b906-8a93e94fe95d",
+    "categories": "Card Draw"
   },
   {
     "name": "Quick Ears",
@@ -8396,13 +8611,14 @@
     "exp": "tbocd",
     "no": 123,
     "img": "http://www.cardgamedb.com/forums/uploads/lotr/MEC43_123.jpg",
+    "unique": "",
     "traits": "",
     "keywords": "",
-    "text": "Response: Exhaust a Dúnedain or Ranger hero to cancel an enemy card just revealed from the encounter deck. Then, shuffle it back into the encounter deck and reveal an additional encounter card.",
-    "flavor": "",
-    "textc": "Response: Exhaust a Dúnedain or Ranger hero to cancel an enemy card just revealed from the encounter deck. Then, shuffle it back into the encounter deck and reveal an additional encounter card.",
+    "text": "Response: Exhaust a D\u00fanedain or Ranger hero to cancel an enemy card just revealed from the encounter deck. Then, shuffle it back into the encounter deck and reveal an additional encounter card.",
+    "textc": "Response: Exhaust a D\u00fanedain or Ranger hero to cancel an enemy card just revealed from the encounter deck. Then, shuffle it back into the encounter deck and reveal an additional encounter card.",
     "name_norm": "Quick Ears",
-    "octgn": "fddb01e7-102e-44c8-a469-e920e76a79e0"
+    "octgn": "fddb01e7-102e-44c8-a469-e920e76a79e0",
+    "categories": ""
   },
   {
     "name": "Favor of the Valar",
@@ -8413,18 +8629,17 @@
     "exp": "tbocd",
     "no": 124,
     "img": "http://www.cardgamedb.com/forums/uploads/lotr/MEC43_124.jpg",
+    "unique": "",
     "traits": " Condition.",
     "keywords": "",
     "text": "Attach to a player's threat dial. Limit 1 per player.\nForced: When you would be eliminated by reaching your threat elimination level, instead discard Favor of the Valar and reduce your threat to 5 less than your threat elimination level. You are not eliminated.",
-    "flavor": "",
     "textc": "Attach to a player's threat dial. Limit 1 per player.\nForced: When you would be eliminated by reaching your threat elimination level, instead discard Favor of the Valar and reduce your threat to 5 less than your threat elimination level. You are not eliminated.",
     "name_norm": "Favor of the Valar",
-    "octgn": "c9cdf75b-7535-4d17-804f-0f22569812c7"
+    "octgn": "c9cdf75b-7535-4d17-804f-0f22569812c7",
+    "categories": "Threat Control"
   },
-
-
   {
-    "name": "Arwen Undómiel",
+    "name": "Arwen Und\u00f3miel",
     "type": "1hero",
     "sphere": "3spirit",
     "cost": 9,
@@ -8440,13 +8655,13 @@
     "traits": " Noldor. Noble.",
     "keywords": "",
     "text": "Action: Discard a card from your hand to add 1 resource to a Noldor hero's resource pool, or to Aragorn's resource pool. (Limit once per round.)",
-    "flavor": null,
     "textc": "Action: Discard a card from your hand to add 1 resource to a Noldor hero's resource pool, or to Aragorn's resource pool. (Limit once per round.)",
     "name_norm": "Arwen Undomiel",
-    "octgn": "21f0ac18-21ea-44b7-b67b-4d1c5baaae0f"
+    "octgn": "21f0ac18-21ea-44b7-b67b-4d1c5baaae0f",
+    "categories": "Resource Acceleration"
   },
   {
-    "name": "Éothain",
+    "name": "\u00c9othain",
     "type": "2ally",
     "sphere": "1leadership",
     "cost": 4,
@@ -8461,14 +8676,14 @@
     "unique": true,
     "traits": " Rohan. Warrior.",
     "keywords": "",
-    "text": "Response: After a Rohan ally is discarded from play by a card effect, ready Éothain.",
-    "flavor": null,
-    "textc": "Response: After a Rohan ally is discarded from play by a card effect, ready Éothain.",
+    "text": "Response: After a Rohan ally is discarded from play by a card effect, ready \u00c9othain.",
+    "textc": "Response: After a Rohan ally is discarded from play by a card effect, ready \u00c9othain.",
     "name_norm": "Eothain",
-    "octgn": "fdabde61-0341-4dae-9a9b-de9f0b955078"
+    "octgn": "fdabde61-0341-4dae-9a9b-de9f0b955078",
+    "categories": ""
   },
   {
-    "name": "Sword of Númenor",
+    "name": "Sword of N\u00famenor",
     "type": "3attachment",
     "sphere": "1leadership",
     "cost": 1,
@@ -8479,11 +8694,11 @@
     "unique": false,
     "traits": " Item. Weapon.",
     "keywords": "Restricted.",
-    "text": "Attach to a Dúnedain or Gondor hero.\nAttached hero gets +1 Attack.\nResponse: After attached hero participates in an attack that destroys an enemy with 5 or more printed hit points, exhaust Sword of Númenor to add 1 resource to attached hero's resource pool.",
-    "flavor": null,
-    "textc": "Restricted.\nAttach to a Dúnedain or Gondor hero.\nAttached hero gets +1 Attack.\nResponse: After attached hero participates in an attack that destroys an enemy with 5 or more printed hit points, exhaust Sword of Númenor to add 1 resource to attached hero's resource pool.",
+    "text": "Attach to a D\u00fanedain or Gondor hero.\nAttached hero gets +1 Attack.\nResponse: After attached hero participates in an attack that destroys an enemy with 5 or more printed hit points, exhaust Sword of N\u00famenor to add 1 resource to attached hero's resource pool.",
+    "textc": "Restricted.\nAttach to a D\u00fanedain or Gondor hero.\nAttached hero gets +1 Attack.\nResponse: After attached hero participates in an attack that destroys an enemy with 5 or more printed hit points, exhaust Sword of N\u00famenor to add 1 resource to attached hero's resource pool.",
     "name_norm": "Sword of Numenor",
-    "octgn": "8a6566b1-2425-442b-8e44-f8a3aa4590fe"
+    "octgn": "8a6566b1-2425-442b-8e44-f8a3aa4590fe",
+    "categories": "Resource Acceleration"
   },
   {
     "name": "Fornost Bowman",
@@ -8499,13 +8714,13 @@
     "no": 143,
     "img": "http://cardgamedb.com/forums/uploads/lotr/MEC44_143.jpg",
     "unique": false,
-    "traits": " Dúnedain. Ranger.",
+    "traits": " D\u00fanedain. Ranger.",
     "keywords": "Ranged.",
     "text": "Fornost Bowman gets +1 Attack for each enemy engaged with you.",
-    "flavor": null,
     "textc": "Ranged.\nFornost Bowman gets +1 Attack for each enemy engaged with you.",
     "name_norm": "Fornost Bowman",
-    "octgn": "40efacf7-f3c1-434b-b31f-42b3721c90c0"
+    "octgn": "40efacf7-f3c1-434b-b31f-42b3721c90c0",
+    "categories": "Attack Bonus"
   },
   {
     "name": "Hour of Wrath",
@@ -8520,10 +8735,10 @@
     "traits": "",
     "keywords": "",
     "text": "Action: Choose a hero. Until the end of the phase, the chose hero does not exhaust to attack or defend.\nValour Action: Choose a player. Until the end of the phase, each of that player's heroes do not exhaust to attack or defend.",
-    "flavor": null,
     "textc": "Action: Choose a hero. Until the end of the phase, the chose hero does not exhaust to attack or defend.\nValour Action: Choose a player. Until the end of the phase, each of that player's heroes do not exhaust to attack or defend.",
     "name_norm": "Hour of Wrath",
-    "octgn": "f88c0606-5076-4df7-beed-a7182af0dece"
+    "octgn": "f88c0606-5076-4df7-beed-a7182af0dece",
+    "categories": ""
   },
   {
     "name": "Elven-light",
@@ -8538,13 +8753,13 @@
     "traits": "",
     "keywords": "",
     "text": "Elven-light can only be played from your discard pile.\nAction: Return Elven-light to your hand from your discard pile. Then, draw 1 card.",
-    "flavor": null,
     "textc": "Elven-light can only be played from your discard pile.\nAction: Return Elven-light to your hand from your discard pile. Then, draw 1 card.",
     "name_norm": "Elven-light",
-    "octgn": "abebff49-8219-4ae0-bd26-266db57bdfc3"
+    "octgn": "abebff49-8219-4ae0-bd26-266db57bdfc3",
+    "categories": "Card Draw"
   },
   {
-    "name": "Tale of Tinúviel",
+    "name": "Tale of Tin\u00faviel",
     "type": "4event",
     "sphere": "3spirit",
     "cost": 1,
@@ -8555,11 +8770,11 @@
     "unique": false,
     "traits": " Song.",
     "keywords": "",
-    "text": "Action: Exhaust a Noldor character to ready a Dúnedain character, or vice-versa. Until the end of the phase, add the exhausted character's printed Willpower to the other character's Willpower, Attack, and Defense.",
-    "flavor": null,
-    "textc": "Action: Exhaust a Noldor character to ready a Dúnedain character, or vice-versa. Until the end of the phase, add the exhausted character's printed Willpower to the other character's Willpower, Attack, and Defense.",
+    "text": "Action: Exhaust a Noldor character to ready a D\u00fanedain character, or vice-versa. Until the end of the phase, add the exhausted character's printed Willpower to the other character's Willpower, Attack, and Defense.",
+    "textc": "Action: Exhaust a Noldor character to ready a D\u00fanedain character, or vice-versa. Until the end of the phase, add the exhausted character's printed Willpower to the other character's Willpower, Attack, and Defense.",
     "name_norm": "Tale of Tinuviel",
-    "octgn": "4d71af80-33cd-4df8-b6da-c479c8a3ae74"
+    "octgn": "4d71af80-33cd-4df8-b6da-c479c8a3ae74",
+    "categories": "Readying"
   },
   {
     "name": "Galadhrim Healer",
@@ -8578,10 +8793,10 @@
     "traits": " Silvan. Healer.",
     "keywords": "",
     "text": "Response: After Galadhrim Healer enters play, choose a player. Heal 1 damage from each hero controlled by that player.",
-    "flavor": null,
     "textc": "Response: After Galadhrim Healer enters play, choose a player. Heal 1 damage from each hero controlled by that player.",
     "name_norm": "Galadhrim Healer",
-    "octgn": "f9865446-f3a4-4a9f-bb1e-68565720511b"
+    "octgn": "f9865446-f3a4-4a9f-bb1e-68565720511b",
+    "categories": "Healing"
   },
   {
     "name": "Weather-stained Cloak",
@@ -8596,10 +8811,10 @@
     "traits": " Item.",
     "keywords": "",
     "text": "Attach to a Ranger character. Limit 1 per character.\nWhile attached character is commited to the quest, Weather-stained cloak gains: \"Response: Exhaust Weather-stained Cloak to cancel 1 point of damage just dealt to attached character.\"",
-    "flavor": null,
     "textc": "Attach to a Ranger character. Limit 1 per character.\nWhile attached character is commited to the quest, Weather-stained cloak gains: \"Response: Exhaust Weather-stained Cloak to cancel 1 point of damage just dealt to attached character.\"",
     "name_norm": "Weather-stained Cloak",
-    "octgn": "2e156c1b-5227-4dfd-a076-ee9b236c86da"
+    "octgn": "2e156c1b-5227-4dfd-a076-ee9b236c86da",
+    "categories": ""
   },
   {
     "name": "Sword-thain",
@@ -8614,313 +8829,305 @@
     "traits": " Title.",
     "keywords": "",
     "text": "Attach to a unique ally belonging to any sphere of influence.\n Attached character loses the ally card type and gains the hero card type.",
-    "flavor": null,
     "textc": "Attach to a unique ally belonging to any sphere of influence.\n Attached character loses the ally card type and gains the hero card type.",
     "name_norm": "Sword-thain",
-    "octgn": "59cd2c5f-1986-4065-ad2c-8423d6b200e2"
-  },
-
-
-
-  {
-    "name":       "Círdan the Shipwright",
-    "type":       "1hero",
-    "sphere":     "3spirit",
-    "cost":       12,
-    "willpower":  4,
-    "strength":   2,
-    "defense":    2,
-    "hitpoints":  4,
-    "cycle":      10,
-    "exp":        "tgh",
-    "no":         1,
-    "img":        "http://www.cardgamedb.com/forums/uploads/lotr/MEC47_1.jpg",
-    "unique":     true,
-    "traits":     "Noldor. Noble.",
-    "keywords":   "",
-    "text":       "Draw 1 additional card at the beginning of the resource phase.\nForced: After drawing cards at the beginning of the resource phase, choose and discard 1 of those cards.",
-    "flavor":     null,
-    "textc":      "Draw 1 additional card at the beginning of the resource phase.\nForced: After drawing cards at the beginning of the resource phase, choose and discard 1 of those cards.",
-    "name_norm":  "Cirdan the Shipwright",
-    "octgn":      "76ee3df4-3ebe-4d2d-9d7f-a0bbe759358a"
+    "octgn": "59cd2c5f-1986-4065-ad2c-8423d6b200e2",
+    "categories": ""
   },
   {
-    "name":       "Galdor of the Havens",
-    "type":       "1hero",
-    "sphere":     "4lore",
-    "cost":       9,
-    "willpower":  2,
-    "strength":   2,
-    "defense":    1,
-    "hitpoints":  4,
-    "cycle":      10,
-    "exp":        "tgh",
-    "no":         2,
-    "img":        "http://www.cardgamedb.com/forums/uploads/lotr/MEC47_2.jpg",
-    "unique":     true,
-    "traits":     "Noldor.",
-    "keywords":   "",
-    "text":       "Response: After drawing your setup hand, instead of taking a mulligan, you may discard any number of cards from your hand. Then, draw that many cards.\nAction: If you have no cards in your hand, draw 6 cards. (Limit once per game.)",
-    "flavor":     null,
-    "textc":      "Response: After drawing your setup hand, instead of taking a mulligan, you may discard any number of cards from your hand. Then, draw that many cards.\nAction: If you have no cards in your hand, draw 6 cards. (Limit once per game.)",
-    "name_norm":  "Galdor of the Havens",
-    "octgn":      "52e217a6-ddc0-4082-9ec2-09d92e8c25c7"
+    "name": "C\u00edrdan the Shipwright",
+    "type": "1hero",
+    "sphere": "3spirit",
+    "cost": 12,
+    "willpower": 4,
+    "strength": 2,
+    "defense": 2,
+    "hitpoints": 4,
+    "cycle": 10,
+    "exp": "tgh",
+    "no": 1,
+    "img": "http://www.cardgamedb.com/forums/uploads/lotr/MEC47_1.jpg",
+    "unique": true,
+    "traits": "Noldor. Noble.",
+    "keywords": "",
+    "text": "Draw 1 additional card at the beginning of the resource phase.\nForced: After drawing cards at the beginning of the resource phase, choose and discard 1 of those cards.",
+    "textc": "Draw 1 additional card at the beginning of the resource phase.\nForced: After drawing cards at the beginning of the resource phase, choose and discard 1 of those cards.",
+    "name_norm": "Cirdan the Shipwright",
+    "octgn": "76ee3df4-3ebe-4d2d-9d7f-a0bbe759358a",
+    "categories": "Card Draw"
   },
   {
-    "name":       "Mithlond Sea-watcher",
-    "type":       "2ally",
-    "sphere":     "2tactics",
-    "cost":       2,
-    "willpower":  1,
-    "strength":   1,
-    "defense":    0,
-    "hitpoints":  2,
-    "cycle":      10,
-    "exp":        "tgh",
-    "no":         3,
-    "img":        "http://www.cardgamedb.com/forums/uploads/lotr/MEC47_3.jpg",
-    "unique":     false,
-    "traits":     "Noldor. Warrior.",
-    "keywords":   "",
-    "text":       "While the top card of your discard pile is an ally, Mithlond Sea-watcher gets +2 Attack and gains ranged.",
-    "flavor":     null,
-    "textc":      "While the top card of your discard pile is an ally, Mithlond Sea-watcher gets +2 Attack and gains ranged.",
-    "name_norm":  "Mithlond Sea-watcher",
-    "octgn":      "3b58bae1-8484-4be6-a75c-1d55c5199f72"
+    "name": "Galdor of the Havens",
+    "type": "1hero",
+    "sphere": "4lore",
+    "cost": 9,
+    "willpower": 2,
+    "strength": 2,
+    "defense": 1,
+    "hitpoints": 4,
+    "cycle": 10,
+    "exp": "tgh",
+    "no": 2,
+    "img": "http://www.cardgamedb.com/forums/uploads/lotr/MEC47_2.jpg",
+    "unique": true,
+    "traits": "Noldor.",
+    "keywords": "",
+    "text": "Response: After drawing your setup hand, instead of taking a mulligan, you may discard any number of cards from your hand. Then, draw that many cards.\nAction: If you have no cards in your hand, draw 6 cards. (Limit once per game.)",
+    "textc": "Response: After drawing your setup hand, instead of taking a mulligan, you may discard any number of cards from your hand. Then, draw that many cards.\nAction: If you have no cards in your hand, draw 6 cards. (Limit once per game.)",
+    "name_norm": "Galdor of the Havens",
+    "octgn": "52e217a6-ddc0-4082-9ec2-09d92e8c25c7",
+    "categories": "Card Draw"
   },
   {
-    "name":       "Skyward Volley",
-    "type":       "4event",
-    "sphere":     "2tactics",
-    "cost":       2,
-    "cycle":      10,
-    "exp":        "tgh",
-    "no":         4,
-    "img":        "http://www.cardgamedb.com/forums/uploads/lotr/MEC47_4.jpg",
-    "unique":     false,
-    "traits":     "",
-    "keywords":   "",
-    "text":       "As an additional cost to play Skyward Volley, exhaust a ranged character you control.\nCombat Action: Deal 2 damage to an enemy engaged with a player. Resolve that effect again for each copy of Skyward Volley currently in your discard pile (you may choose different targets).",
-    "flavor":     null,
-    "textc":      "As an additional cost to play Skyward Volley, exhaust a ranged character you control.\nCombat Action: Deal 2 damage to an enemy engaged with a player. Resolve that effect again for each copy of Skyward Volley currently in your discard pile (you may choose different targets).",
-    "name_norm":  "Skyward Volley",
-    "octgn":      "bd3686ef-e3d2-4dea-9fc3-aa039918f0b1"
+    "name": "Mithlond Sea-watcher",
+    "type": "2ally",
+    "sphere": "2tactics",
+    "cost": 2,
+    "willpower": 1,
+    "strength": 1,
+    "defense": 0,
+    "hitpoints": 2,
+    "cycle": 10,
+    "exp": "tgh",
+    "no": 3,
+    "img": "http://www.cardgamedb.com/forums/uploads/lotr/MEC47_3.jpg",
+    "unique": false,
+    "traits": "Noldor. Warrior.",
+    "keywords": "",
+    "text": "While the top card of your discard pile is an ally, Mithlond Sea-watcher gets +2 Attack and gains ranged.",
+    "textc": "While the top card of your discard pile is an ally, Mithlond Sea-watcher gets +2 Attack and gains ranged.",
+    "name_norm": "Mithlond Sea-watcher",
+    "octgn": "3b58bae1-8484-4be6-a75c-1d55c5199f72",
+    "categories": "Attack Bonus"
   },
   {
-    "name":       "Grappling Hook",
-    "type":       "3attachment",
-    "sphere":     "2tactics",
-    "cost":       1,
-    "cycle":      10,
-    "exp":        "tgh",
-    "no":         5,
-    "img":        "http://www.cardgamedb.com/forums/uploads/lotr/MEC47_5.jpg",
-    "unique":     false,
-    "traits":     "Item.",
-    "keywords":   "",
-    "text":       "Attach to a character.\nQuest Action: Discard Grappling Hook and exhaust attached character to commit attached character to the quest, using its Attack instead of its Willpower (or instead of its Defense if the current quest has the siege keyword).",
-    "flavor":     null,
-    "textc":      "Attach to a character.\nQuest Action: Discard Grappling Hook and exhaust attached character to commit attached character to the quest, using its Attack instead of its Willpower (or instead of its Defense if the current quest has the siege keyword).",
-    "name_norm":  "Grappling Hook",
-    "octgn":      "1ccd4cc5-9e8a-41ea-b897-61e47bba5ae6"
+    "name": "Skyward Volley",
+    "type": "4event",
+    "sphere": "2tactics",
+    "cost": 2,
+    "cycle": 10,
+    "exp": "tgh",
+    "no": 4,
+    "img": "http://www.cardgamedb.com/forums/uploads/lotr/MEC47_4.jpg",
+    "unique": false,
+    "traits": "",
+    "keywords": "",
+    "text": "As an additional cost to play Skyward Volley, exhaust a ranged character you control.\nCombat Action: Deal 2 damage to an enemy engaged with a player. Resolve that effect again for each copy of Skyward Volley currently in your discard pile (you may choose different targets).",
+    "textc": "As an additional cost to play Skyward Volley, exhaust a ranged character you control.\nCombat Action: Deal 2 damage to an enemy engaged with a player. Resolve that effect again for each copy of Skyward Volley currently in your discard pile (you may choose different targets).",
+    "name_norm": "Skyward Volley",
+    "octgn": "bd3686ef-e3d2-4dea-9fc3-aa039918f0b1",
+    "categories": "Direct Damage"
   },
   {
-    "name":       "Warden of the Havens",
-    "type":       "2ally",
-    "sphere":     "1leadership",
-    "cost":       2,
-    "willpower":  0,
-    "strength":   1,
-    "defense":    1,
-    "hitpoints":  3,
-    "cycle":      10,
-    "exp":        "tgh",
-    "no":         6,
-    "img":        "http://www.cardgamedb.com/forums/uploads/lotr/MEC47_6.jpg",
-    "unique":     false,
-    "traits":     "Noldor. Warrior.",
-    "keywords":   "",
-    "text":       "While the top card of your discard pile is an attachment, Warden of the Havens gets +2 Defense and gains sentinel.",
-    "flavor":     null,
-    "textc":      "While the top card of your discard pile is an attachment, Warden of the Havens gets +2 Defense and gains sentinel.",
-    "name_norm":  "Warden of the Havens",
-    "octgn":      "94df6677-1e7c-4ccc-932c-f750b51a769c"
+    "name": "Grappling Hook",
+    "type": "3attachment",
+    "sphere": "2tactics",
+    "cost": 1,
+    "cycle": 10,
+    "exp": "tgh",
+    "no": 5,
+    "img": "http://www.cardgamedb.com/forums/uploads/lotr/MEC47_5.jpg",
+    "unique": false,
+    "traits": "Item.",
+    "keywords": "",
+    "text": "Attach to a character.\nQuest Action: Discard Grappling Hook and exhaust attached character to commit attached character to the quest, using its Attack instead of its Willpower (or instead of its Defense if the current quest has the siege keyword).",
+    "textc": "Attach to a character.\nQuest Action: Discard Grappling Hook and exhaust attached character to commit attached character to the quest, using its Attack instead of its Willpower (or instead of its Defense if the current quest has the siege keyword).",
+    "name_norm": "Grappling Hook",
+    "octgn": "1ccd4cc5-9e8a-41ea-b897-61e47bba5ae6",
+    "categories": ""
   },
   {
-    "name":       "Anchor Watch",
-    "type":       "4event",
-    "sphere":     "1leadership",
-    "cost":       2,
-    "cycle":      10,
-    "exp":        "tgh",
-    "no":         7,
-    "img":        "http://www.cardgamedb.com/forums/uploads/lotr/MEC47_7.jpg",
-    "unique":     false,
-    "traits":     "",
-    "keywords":   "",
-    "text":       "Response: After an enemy is declared as an attacker against you, declare an exhausted character you control as the defender. Resolve that effect again for each copy of Anchor Watch currently in your discard pile (all chosen characters are defending against this attack).",
-    "flavor":     null,
-    "textc":      "Response: After an enemy is declared as an attacker against you, declare an exhausted character you control as the defender. Resolve that effect again for each copy of Anchor Watch currently in your discard pile (all chosen characters are defending against this attack).",
-    "name_norm":  "Anchor Watch",
-    "octgn":      "dd64881e-99d9-4505-9f9f-67dfc8c8ffc1"
+    "name": "Warden of the Havens",
+    "type": "2ally",
+    "sphere": "1leadership",
+    "cost": 2,
+    "willpower": 0,
+    "strength": 1,
+    "defense": 1,
+    "hitpoints": 3,
+    "cycle": 10,
+    "exp": "tgh",
+    "no": 6,
+    "img": "http://www.cardgamedb.com/forums/uploads/lotr/MEC47_6.jpg",
+    "unique": false,
+    "traits": "Noldor. Warrior.",
+    "keywords": "",
+    "text": "While the top card of your discard pile is an attachment, Warden of the Havens gets +2 Defense and gains sentinel.",
+    "textc": "While the top card of your discard pile is an attachment, Warden of the Havens gets +2 Defense and gains sentinel.",
+    "name_norm": "Warden of the Havens",
+    "octgn": "94df6677-1e7c-4ccc-932c-f750b51a769c",
+    "categories": "Defense Bonus"
   },
   {
-    "name":       "Mariner's Compass",
-    "type":       "3attachment",
-    "sphere":     "1leadership",
-    "cost":       1,
-    "exp":        "tgh",
-    "no":         8,
-    "img":        "http://www.cardgamedb.com/forums/uploads/lotr/MEC47_8.jpg",
-    "unique":     false,
-    "traits":     "Item.",
-    "keywords":   "",
-    "text":       "Attach to a Leadership or a Scout character.\nResponse: At the beginning of the travel phase, exhaust Mariner's Compass and attached character to search the top 5 cards of the encounter deck for a location. Switch that location with a location in the staging area. Shuffle the encounter deck.",
-    "flavor":     null,
-    "textc":      "Attach to a Leadership or a Scout character.\nResponse: At the beginning of the travel phase, exhaust Mariner's Compass and attached character to search the top 5 cards of the encounter deck for a location. Switch that location with a location in the staging area. Shuffle the encounter deck.",
-    "name_norm":  "Mariner's Compass",
-    "octgn":      "fe1a0aef-10bd-441b-a27b-0527810fef57"
+    "name": "Anchor Watch",
+    "type": "4event",
+    "sphere": "1leadership",
+    "cost": 2,
+    "cycle": 10,
+    "exp": "tgh",
+    "no": 7,
+    "img": "http://www.cardgamedb.com/forums/uploads/lotr/MEC47_7.jpg",
+    "unique": false,
+    "traits": "",
+    "keywords": "",
+    "text": "Response: After an enemy is declared as an attacker against you, declare an exhausted character you control as the defender. Resolve that effect again for each copy of Anchor Watch currently in your discard pile (all chosen characters are defending against this attack).",
+    "textc": "Response: After an enemy is declared as an attacker against you, declare an exhausted character you control as the defender. Resolve that effect again for each copy of Anchor Watch currently in your discard pile (all chosen characters are defending against this attack).",
+    "name_norm": "Anchor Watch",
+    "octgn": "dd64881e-99d9-4505-9f9f-67dfc8c8ffc1",
+    "categories": ""
   },
   {
-    "name":       "Lindon Navigator",
-    "type":       "2ally",
-    "sphere":     "4lore",
-    "cost":       2,
-    "willpower":  2,
-    "strength":   1,
-    "defense":    1,
-    "hitpoints":  2,
-    "cycle":      10,
-    "exp":        "tgh",
-    "no":         9,
-    "img":        "http://www.cardgamedb.com/forums/uploads/lotr/MEC47_9.jpg",
-    "unique":     false,
-    "traits":     "Noldor. Scout.",
-    "keywords":   "",
-    "text":       "Lindon Navigator does not exhaust to commit to a quest, and can commit to quests while exhausted.\nForced: After resolving a quest to which Lindon Navigator was committed, either discard it from play or discard 1 card from your hand.",
-    "flavor":     null,
-    "textc":      "Lindon Navigator does not exhaust to commit to a quest, and can commit to quests while exhausted.\nForced: After resolving a quest to which Lindon Navigator was committed, either discard it from play or discard 1 card from your hand.",
-    "name_norm":  "Lindon Navigator",
-    "octgn":      "a09013c9-0eeb-459d-b7fc-d803d1b0ad1d"
+    "name": "Mariner's Compass",
+    "type": "3attachment",
+    "sphere": "1leadership",
+    "cost": 1,
+    "cycle": 0,
+    "exp": "tgh",
+    "no": 8,
+    "img": "http://www.cardgamedb.com/forums/uploads/lotr/MEC47_8.jpg",
+    "unique": false,
+    "traits": "Item.",
+    "keywords": "",
+    "text": "Attach to a Leadership or a Scout character.\nResponse: At the beginning of the travel phase, exhaust Mariner's Compass and attached character to search the top 5 cards of the encounter deck for a location. Switch that location with a location in the staging area. Shuffle the encounter deck.",
+    "textc": "Attach to a Leadership or a Scout character.\nResponse: At the beginning of the travel phase, exhaust Mariner's Compass and attached character to search the top 5 cards of the encounter deck for a location. Switch that location with a location in the staging area. Shuffle the encounter deck.",
+    "name_norm": "Mariner's Compass",
+    "octgn": "fe1a0aef-10bd-441b-a27b-0527810fef57",
+    "categories": ""
   },
   {
-    "name":       "The Evening Star",
-    "type":       "4event",
-    "sphere":     "4lore",
-    "cost":       2,
-    "cycle":      10,
-    "exp":        "tgh",
-    "no":         10,
-    "img":        "http://www.cardgamedb.com/forums/uploads/lotr/MEC47_10.jpg",
-    "unique":     false,
-    "traits":     "",
-    "keywords":   "",
-    "text":       "Action: Place 2 progress on any location. Resolve that effect again for each copy of The Evening Star currently in your discard pile (you may choose new targets).",
-    "flavor":     null,
-    "textc":      "Action: Place 2 progress on any location. Resolve that effect again for each copy of The Evening Star currently in your discard pile (you may choose new targets).",
-    "name_norm":  "The Evening Star",
-    "octgn":      "b6729381-3bfc-41fa-abd1-99f410eb19b8"
+    "name": "Lindon Navigator",
+    "type": "2ally",
+    "sphere": "4lore",
+    "cost": 2,
+    "willpower": 2,
+    "strength": 1,
+    "defense": 1,
+    "hitpoints": 2,
+    "cycle": 10,
+    "exp": "tgh",
+    "no": 9,
+    "img": "http://www.cardgamedb.com/forums/uploads/lotr/MEC47_9.jpg",
+    "unique": false,
+    "traits": "Noldor. Scout.",
+    "keywords": "",
+    "text": "Lindon Navigator does not exhaust to commit to a quest, and can commit to quests while exhausted.\nForced: After resolving a quest to which Lindon Navigator was committed, either discard it from play or discard 1 card from your hand.",
+    "textc": "Lindon Navigator does not exhaust to commit to a quest, and can commit to quests while exhausted.\nForced: After resolving a quest to which Lindon Navigator was committed, either discard it from play or discard 1 card from your hand.",
+    "name_norm": "Lindon Navigator",
+    "octgn": "a09013c9-0eeb-459d-b7fc-d803d1b0ad1d",
+    "categories": ""
   },
   {
-    "name":       "Explorer's Almanac",
-    "type":       "3attachment",
-    "sphere":     "4lore",
-    "cost":       0,
-    "cycle":      10,
-    "exp":        "tgh",
-    "no":         11,
-    "img":        "http://www.cardgamedb.com/forums/uploads/lotr/MEC47_11.jpg",
-    "unique":     false,
-    "traits":     "Item.",
-    "keywords":   "",
-    "text":       "Attach to a location in the staging area.\nProgress from questing successfully may be placed on the attached location before it is placed on the current quest.",
-    "flavor":     null,
-    "textc":      "Attach to a location in the staging area.\nProgress from questing successfully may be placed on the attached location before it is placed on the current quest.",
-    "name_norm":  "Explorer's Almanac",
-    "octgn":      "21f0acdb-5d11-409e-80f8-c717fab87ab9"
+    "name": "The Evening Star",
+    "type": "4event",
+    "sphere": "4lore",
+    "cost": 2,
+    "cycle": 10,
+    "exp": "tgh",
+    "no": 10,
+    "img": "http://www.cardgamedb.com/forums/uploads/lotr/MEC47_10.jpg",
+    "unique": false,
+    "traits": "",
+    "keywords": "",
+    "text": "Action: Place 2 progress on any location. Resolve that effect again for each copy of The Evening Star currently in your discard pile (you may choose new targets).",
+    "textc": "Action: Place 2 progress on any location. Resolve that effect again for each copy of The Evening Star currently in your discard pile (you may choose new targets).",
+    "name_norm": "The Evening Star",
+    "octgn": "b6729381-3bfc-41fa-abd1-99f410eb19b8",
+    "categories": ""
   },
   {
-    "name":       "Sailor of Lune",
-    "type":       "2ally",
-    "sphere":     "3spirit",
-    "cost":       2,
-    "willpower":  1,
-    "strength":   1,
-    "defense":    0,
-    "hitpoints":  2,
-    "cycle":      10,
-    "exp":        "tgh",
-    "no":         12,
-    "img":        "http://www.cardgamedb.com/forums/uploads/lotr/MEC47_12.jpg",
-    "unique":     false,
-    "traits":     "Noldor. Scout.",
-    "keywords":   "",
-    "text":       "While the top card of your discard pile is an event, Sailor of Lune gets +1 Willpower and gains: \"Cannot be damaged while committed to the quest.\"",
-    "flavor":     null,
-    "textc":      "While the top card of your discard pile is an event, Sailor of Lune gets +1 Willpower and gains: \"Cannot be damaged while committed to the quest.\"",
-    "name_norm":  "Sailor of Lune",
-    "octgn":      "85a269eb-63f1-4f63-83c9-30b718d364f6"
+    "name": "Explorer's Almanac",
+    "type": "3attachment",
+    "sphere": "4lore",
+    "cost": 0,
+    "cycle": 10,
+    "exp": "tgh",
+    "no": 11,
+    "img": "http://www.cardgamedb.com/forums/uploads/lotr/MEC47_11.jpg",
+    "unique": false,
+    "traits": "Item.",
+    "keywords": "",
+    "text": "Attach to a location in the staging area.\nProgress from questing successfully may be placed on the attached location before it is placed on the current quest.",
+    "textc": "Attach to a location in the staging area.\nProgress from questing successfully may be placed on the attached location before it is placed on the current quest.",
+    "name_norm": "Explorer's Almanac",
+    "octgn": "21f0acdb-5d11-409e-80f8-c717fab87ab9",
+    "categories": ""
   },
   {
-    "name":       "Elwing's Flight",
-    "type":       "4event",
-    "sphere":     "3spirit",
-    "cost":       2,
-    "cycle":      10,
-    "exp":        "tgh",
-    "no":         13,
-    "img":        "http://www.cardgamedb.com/forums/uploads/lotr/MEC47_13.jpg",
-    "unique":     false,
-    "traits":     "",
-    "keywords":   "",
-    "text":       "Quest Action: Ready a questing character and give that character +1 Willpower until the end of the phase. Resolve that effect again for each copy of Elwing's Flight currently in your discard pile (you may choose different targets).",
-    "flavor":     null,
-    "textc":      "Quest Action: Ready a questing character and give that character +1 Willpower until the end of the phase. Resolve that effect again for each copy of Elwing's Flight currently in your discard pile (you may choose different targets).",
-    "name_norm":  "Elwing's Flight",
-    "octgn":      "d25dfbee-85c4-42f8-9653-c0536d3e5095"
+    "name": "Sailor of Lune",
+    "type": "2ally",
+    "sphere": "3spirit",
+    "cost": 2,
+    "willpower": 1,
+    "strength": 1,
+    "defense": 0,
+    "hitpoints": 2,
+    "cycle": 10,
+    "exp": "tgh",
+    "no": 12,
+    "img": "http://www.cardgamedb.com/forums/uploads/lotr/MEC47_12.jpg",
+    "unique": false,
+    "traits": "Noldor. Scout.",
+    "keywords": "",
+    "text": "While the top card of your discard pile is an event, Sailor of Lune gets +1 Willpower and gains: \"Cannot be damaged while committed to the quest.\"",
+    "textc": "While the top card of your discard pile is an event, Sailor of Lune gets +1 Willpower and gains: \"Cannot be damaged while committed to the quest.\"",
+    "name_norm": "Sailor of Lune",
+    "octgn": "85a269eb-63f1-4f63-83c9-30b718d364f6",
+    "categories": ""
   },
   {
-    "name":       "To the Sea, to the Sea!",
-    "type":       "3attachment",
-    "sphere":     "3spirit",
-    "cost":       1,
-    "cycle":      10,
-    "exp":        "tgh",
-    "no":         14,
-    "img":        "http://www.cardgamedb.com/forums/uploads/lotr/MEC47_14.jpg",
-    "unique":     true,
-    "traits":     "Song.",
-    "keywords":   "",
-    "text":       "Attach to a Noldor character.\nAction: Exhaust To the Sea, to the Sea! and discard X cards from your hand to reduce the cost of the next Noldor ally played this phase by X (to a minimum of 1).",
-    "flavor":     null,
-    "textc":      "Attach to a Noldor character.\nAction: Exhaust To the Sea, to the Sea! and discard X cards from your hand to reduce the cost of the next Noldor ally played this phase by X (to a minimum of 1).",
-    "name_norm":  "To the Sea to the Sea",
-    "octgn":      "d0180ea8-15e3-4a9a-80c6-dfd6549753c9"
+    "name": "Elwing's Flight",
+    "type": "4event",
+    "sphere": "3spirit",
+    "cost": 2,
+    "cycle": 10,
+    "exp": "tgh",
+    "no": 13,
+    "img": "http://www.cardgamedb.com/forums/uploads/lotr/MEC47_13.jpg",
+    "unique": false,
+    "traits": "",
+    "keywords": "",
+    "text": "Quest Action: Ready a questing character and give that character +1 Willpower until the end of the phase. Resolve that effect again for each copy of Elwing's Flight currently in your discard pile (you may choose different targets).",
+    "textc": "Quest Action: Ready a questing character and give that character +1 Willpower until the end of the phase. Resolve that effect again for each copy of Elwing's Flight currently in your discard pile (you may choose different targets).",
+    "name_norm": "Elwing's Flight",
+    "octgn": "d25dfbee-85c4-42f8-9653-c0536d3e5095",
+    "categories": "Readying"
   },
   {
-    "name":       "Narya",
-    "type":       "3attachment",
-    "sphere":     "5neutral",
-    "cost":       2,
-    "cycle":      10,
-    "exp":        "tgh",
-    "no":         15,
-    "img":        "http://www.cardgamedb.com/forums/uploads/lotr/MEC47_15.jpg",
-    "unique":     true,
-    "traits":     "Ring. Artifact.",
-    "keywords":   "",
-    "text":       "Attach to Círdan the Shipwright or Gandalf.\nAttached character gains a Leadership resource icon.\nAction: Exhaust Narya and attached character to choose and ready up to 2 allies. Each of those allies gets +1 Attack and +1 Defense until the end of the phase.",
-    "flavor":     null,
-    "textc":      "Attach to Círdan the Shipwright or Gandalf.\nAttached character gains a Leadership resource icon.\nAction: Exhaust Narya and attached character to choose and ready up to 2 allies. Each of those allies gets +1 Attack and +1 Defense until the end of the phase.",
-    "name_norm":  "Narya",
-    "octgn":      "8ae15724-e823-4f55-a9e8-c75b3e795e9a"
+    "name": "To the Sea, to the Sea!",
+    "type": "3attachment",
+    "sphere": "3spirit",
+    "cost": 1,
+    "cycle": 10,
+    "exp": "tgh",
+    "no": 14,
+    "img": "http://www.cardgamedb.com/forums/uploads/lotr/MEC47_14.jpg",
+    "unique": true,
+    "traits": "Song.",
+    "keywords": "",
+    "text": "Attach to a Noldor character.\nAction: Exhaust To the Sea, to the Sea! and discard X cards from your hand to reduce the cost of the next Noldor ally played this phase by X (to a minimum of 1).",
+    "textc": "Attach to a Noldor character.\nAction: Exhaust To the Sea, to the Sea! and discard X cards from your hand to reduce the cost of the next Noldor ally played this phase by X (to a minimum of 1).",
+    "name_norm": "To the Sea to the Sea",
+    "octgn": "d0180ea8-15e3-4a9a-80c6-dfd6549753c9",
+    "categories": ""
   },
-
-
-
-
-
-
+  {
+    "name": "Narya",
+    "type": "3attachment",
+    "sphere": "5neutral",
+    "cost": 2,
+    "cycle": 10,
+    "exp": "tgh",
+    "no": 15,
+    "img": "http://www.cardgamedb.com/forums/uploads/lotr/MEC47_15.jpg",
+    "unique": true,
+    "traits": "Ring. Artifact.",
+    "keywords": "",
+    "text": "Attach to C\u00edrdan the Shipwright or Gandalf.\nAttached character gains a Leadership resource icon.\nAction: Exhaust Narya and attached character to choose and ready up to 2 allies. Each of those allies gets +1 Attack and +1 Defense until the end of the phase.",
+    "textc": "Attach to C\u00edrdan the Shipwright or Gandalf.\nAttached character gains a Leadership resource icon.\nAction: Exhaust Narya and attached character to choose and ready up to 2 allies. Each of those allies gets +1 Attack and +1 Defense until the end of the phase.",
+    "name_norm": "Narya",
+    "octgn": "8ae15724-e823-4f55-a9e8-c75b3e795e9a",
+    "categories": "Attack Bonus, Readying, Defense Bonus, Resource Smoothing"
+  },
   {
     "name": "Bilbo Baggins",
     "type": "1hero",
@@ -8938,10 +9145,10 @@
     "traits": " Hobbit.",
     "keywords": "",
     "text": "The first player gains control of Bilbo Baggins.\nBilbo Baggins cannot gain resources from player card effects.\nIf Bilbo Baggins leaves play, the players lose the game.",
-    "flavor": null,
     "textc": "The first player gains control of Bilbo Baggins.\nBilbo Baggins cannot gain resources from player card effects.\nIf Bilbo Baggins leaves play, the players lose the game.",
     "name_norm": "Bilbo Baggins",
-    "octgn": "51223bd0-ffd1-11df-a976-1801204c9017"
+    "octgn": "51223bd0-ffd1-11df-a976-1801204c9017",
+    "categories": ""
   },
   {
     "name": "Thorin Oakenshield",
@@ -8960,10 +9167,10 @@
     "traits": " Dwarf. Noble. Warrior.",
     "keywords": "",
     "text": "If you control at least 5 Dwarf characters, add 1 additional resource to Thorin Oakenshield's pool when you collect resources during the resource phase.",
-    "flavor": null,
     "textc": "If you control at least 5 Dwarf characters, add 1 additional resource to Thorin Oakenshield's pool when you collect resources during the resource phase.",
     "name_norm": "Thorin Oakenshield",
-    "octgn": "51223bd0-ffd1-11df-a976-1801204c9083"
+    "octgn": "51223bd0-ffd1-11df-a976-1801204c9083",
+    "categories": ""
   },
   {
     "name": "Nori",
@@ -8985,7 +9192,8 @@
     "flavor": "`Nori, at your service.` -Nori, The Hobbit",
     "textc": "Response: After you play a Dwarf character from your hand, reduce your threat by 1.",
     "name_norm": "Nori",
-    "octgn": "51223bd0-ffd1-11df-a976-1801204c9062"
+    "octgn": "51223bd0-ffd1-11df-a976-1801204c9062",
+    "categories": "Threat Control"
   },
   {
     "name": "Ori",
@@ -9007,7 +9215,8 @@
     "flavor": "`He could write well and speedily, and often used the Elvish characters.` -Gimli, The Fellowship of the Ring",
     "textc": "If you control at least 5 Dwarf characters, draw 1 additional card at the beginning of the resource phase.",
     "name_norm": "Ori",
-    "octgn": "51223bd0-ffd1-11df-a976-1801204c9065"
+    "octgn": "51223bd0-ffd1-11df-a976-1801204c9065",
+    "categories": "Card Draw"
   },
   {
     "name": "Beorn",
@@ -9026,10 +9235,10 @@
     "traits": " Beorning. Warrior.",
     "keywords": "Sentinel.",
     "text": "Cannot have attachments. Immune to player card effects.\nBeorn does not exhaust to defend.",
-    "flavor": null,
     "textc": "Sentinel.\nCannot have attachments. Immune to player card effects.\nBeorn does not exhaust to defend.",
     "name_norm": "Beorn",
-    "octgn": "51223bd0-ffd1-11df-a976-1801204c9015"
+    "octgn": "51223bd0-ffd1-11df-a976-1801204c9015",
+    "categories": ""
   },
   {
     "name": "Fili",
@@ -9048,10 +9257,10 @@
     "traits": " Dwarf.",
     "keywords": "",
     "text": "Response: After you play Fili from your hand during the planning phase, search your deck for Kili and put him into play under your control. Then, shuffle your deck.",
-    "flavor": null,
     "textc": "Response: After you play Fili from your hand during the planning phase, search your deck for Kili and put him into play under your control. Then, shuffle your deck.",
     "name_norm": "Fili",
-    "octgn": "51223bd0-ffd1-11df-a976-1801204c9032"
+    "octgn": "51223bd0-ffd1-11df-a976-1801204c9032",
+    "categories": "Card Search"
   },
   {
     "name": "Kili",
@@ -9070,10 +9279,10 @@
     "traits": " Dwarf.",
     "keywords": "",
     "text": "Response: After you play Kili from your hand during the planning phase, search your deck for Fili and put him into play under your control. Then, shuffle your deck.",
-    "flavor": null,
     "textc": "Response: After you play Kili from your hand during the planning phase, search your deck for Fili and put him into play under your control. Then, shuffle your deck.",
     "name_norm": "Kili",
-    "octgn": "51223bd0-ffd1-11df-a976-1801204c9055"
+    "octgn": "51223bd0-ffd1-11df-a976-1801204c9055",
+    "categories": "Card Search"
   },
   {
     "name": "Bofur",
@@ -9092,10 +9301,10 @@
     "traits": " Dwarf.",
     "keywords": "",
     "text": "Action: Exhaust Bofur to search the top 5 cards of your deck for 1 Weapon attachment. Add that card to your hand and shuffle the other cards back into your deck.",
-    "flavor": null,
     "textc": "Action: Exhaust Bofur to search the top 5 cards of your deck for 1 Weapon attachment. Add that card to your hand and shuffle the other cards back into your deck.",
     "name_norm": "Bofur",
-    "octgn": "51223bd0-ffd1-11df-a976-1801204c9019"
+    "octgn": "51223bd0-ffd1-11df-a976-1801204c9019",
+    "categories": "Card Search"
   },
   {
     "name": "Dori",
@@ -9114,10 +9323,10 @@
     "traits": " Dwarf.",
     "keywords": "",
     "text": "Response: After a hero is assigned any amount of damage, exhaust Dori to place that damage on Dori instead.",
-    "flavor": null,
     "textc": "Response: After a hero is assigned any amount of damage, exhaust Dori to place that damage on Dori instead.",
     "name_norm": "Dori",
-    "octgn": "51223bd0-ffd1-11df-a976-1801204c9027"
+    "octgn": "51223bd0-ffd1-11df-a976-1801204c9027",
+    "categories": ""
   },
   {
     "name": "Gandalf",
@@ -9136,10 +9345,10 @@
     "traits": " Istari.",
     "keywords": "",
     "text": "Gandalf does not exhaust to commit to a quest.\nForced: At the end of the refresh phase, discard Gandalf from play. You may raise your threat by 2 to cancel this effect.",
-    "flavor": null,
     "textc": "Gandalf does not exhaust to commit to a quest.\nForced: At the end of the refresh phase, discard Gandalf from play. You may raise your threat by 2 to cancel this effect.",
     "name_norm": "Gandalf",
-    "octgn": "51223bd0-ffd1-11df-a976-1801204c9036"
+    "octgn": "51223bd0-ffd1-11df-a976-1801204c9036",
+    "categories": ""
   },
   {
     "name": "Cram",
@@ -9154,10 +9363,10 @@
     "traits": " Item.",
     "keywords": "",
     "text": "Attach to a hero.\nAction: Discard Cram to ready attached hero.",
-    "flavor": null,
     "textc": "Attach to a hero.\nAction: Discard Cram to ready attached hero.",
     "name_norm": "Cram",
-    "octgn": "51223bd0-ffd1-11df-a976-1801204c9024"
+    "octgn": "51223bd0-ffd1-11df-a976-1801204c9024",
+    "categories": "Readying"
   },
   {
     "name": "Spare Hood and Cloak",
@@ -9175,7 +9384,8 @@
     "flavor": "`You will have to manage without pocket-handkerchiefs, and a good many other things, before you get to the journey's end. As for a hat, I have got a spare hood and cloak in my luggage.` -Dwalin, The Hobbit",
     "textc": "Attach to a character.\nAction: Exhaust Spare Hood and Cloak and exhaust attached character to ready another character. Then, attach Spare Hood and Cloak to that character.",
     "name_norm": "Spare Hood and Cloak",
-    "octgn": "51223bd0-ffd1-11df-a976-1801204c9074"
+    "octgn": "51223bd0-ffd1-11df-a976-1801204c9074",
+    "categories": "Readying"
   },
   {
     "name": "Thror's Map",
@@ -9193,7 +9403,8 @@
     "flavor": "`This was made by Thror, your grandfather, Thorin.` he said in answer to the dwarves' excited questions. `It is a plan of the Mountain.` -Gandalf, The Hobbit",
     "textc": "Attach to a hero.\nTravel Action: Exhaust Thror's Map to choose a location in the staging area. Make that location the active location. (If there is another active location, return it to the staging area.)",
     "name_norm": "Thror's Map",
-    "octgn": "51223bd0-ffd1-11df-a976-1801204c9084"
+    "octgn": "51223bd0-ffd1-11df-a976-1801204c9084",
+    "categories": ""
   },
   {
     "name": "A Very Good Tale",
@@ -9208,10 +9419,10 @@
     "traits": "",
     "keywords": "",
     "text": "Action: Exhaust 2 allies you control to shuffle your deck and discard the top 5 cards. Put up to 2 allies discarded by this effect into play under your control. The total cost of the allies put into play cannot exceed the total cost of the allies exhausted to pay for this effect.",
-    "flavor": null,
     "textc": "Action: Exhaust 2 allies you control to shuffle your deck and discard the top 5 cards. Put up to 2 allies discarded by this effect into play under your control. The total cost of the allies put into play cannot exceed the total cost of the allies exhausted to pay for this effect.",
     "name_norm": "A Very Good Tale",
-    "octgn": "51223bd0-ffd1-11df-a976-1801204c9011"
+    "octgn": "51223bd0-ffd1-11df-a976-1801204c9011",
+    "categories": ""
   },
   {
     "name": "Foe-hammer",
@@ -9226,10 +9437,10 @@
     "traits": "",
     "keywords": "",
     "text": "Response: After a hero you control attacks and destroys an enemy, exhaust a Weapon card attached to that hero to draw 3 cards.",
-    "flavor": null,
     "textc": "Response: After a hero you control attacks and destroys an enemy, exhaust a Weapon card attached to that hero to draw 3 cards.",
     "name_norm": "Foe-hammer",
-    "octgn": "51223bd0-ffd1-11df-a976-1801204c9033"
+    "octgn": "51223bd0-ffd1-11df-a976-1801204c9033",
+    "categories": "Card Draw"
   },
   {
     "name": "Goblin-cleaver",
@@ -9247,7 +9458,8 @@
     "flavor": "At this point Gandalf fell behind, and Thorin with him. They turned a sharp corner. `About turn!` he shouted. `Draw your sword, Thorin!` - The Hobbit",
     "textc": "Combat Action: Exhaust a Weapon card attached to a hero you control to choose an enemy engaged with you. Deal 2 damage to that enemy. (Deal 3 damage instead if the enemy is an Orc.)",
     "name_norm": "Goblin-cleaver",
-    "octgn": "51223bd0-ffd1-11df-a976-1801204c9043"
+    "octgn": "51223bd0-ffd1-11df-a976-1801204c9043",
+    "categories": "Direct Damage"
   },
   {
     "name": "Late Adventurer",
@@ -9265,7 +9477,8 @@
     "flavor": "To the end of his days Bilbo could never remember how he found himself outside, without a hat, walking-stick or any money, or anything that he usually took when he went out. -The Hobbit",
     "textc": "Quest Action: Exhaust a character you control that is not committed to the quest to commit that character to the quest.",
     "name_norm": "Late Adventurer",
-    "octgn": "51223bd0-ffd1-11df-a976-1801204c9057"
+    "octgn": "51223bd0-ffd1-11df-a976-1801204c9057",
+    "categories": ""
   },
   {
     "name": "Expecting Mischief",
@@ -9280,10 +9493,10 @@
     "traits": "",
     "keywords": "",
     "text": "Play during the quest phase, before the staging step.\nAction: Deal 2 damage to the first enemy revealed from the encounter deck this phase.",
-    "flavor": null,
     "textc": "Play during the quest phase, before the staging step.\nAction: Deal 2 damage to the first enemy revealed from the encounter deck this phase.",
     "name_norm": "Expecting Mischief",
-    "octgn": "51223bd0-ffd1-11df-a976-1801204c9031"
+    "octgn": "51223bd0-ffd1-11df-a976-1801204c9031",
+    "categories": "Direct Damage"
   },
   {
     "name": "Burglar Baggins",
@@ -9298,10 +9511,10 @@
     "traits": "",
     "keywords": "",
     "text": "Action: Bilbo Baggins gets +2 Willpower, +2 Attack, and +2 Defense until the end of the phase. (You may spend a Baggins resource from Bilbo Baggins' resource pool to play this card even if you do not control Bilbo Baggins.)",
-    "flavor": null,
     "textc": "Action: Bilbo Baggins gets +2 Willpower, +2 Attack, and +2 Defense until the end of the phase. (You may spend a Baggins resource from Bilbo Baggins' resource pool to play this card even if you do not control Bilbo Baggins.)",
     "name_norm": "Burglar Baggins",
-    "octgn": "51223bd0-ffd1-11df-a976-1801204c9020"
+    "octgn": "51223bd0-ffd1-11df-a976-1801204c9020",
+    "categories": "Defense Bonus"
   },
   {
     "name": "Bilbo Baggins",
@@ -9320,10 +9533,10 @@
     "traits": " Hobbit. Burglar.",
     "keywords": "",
     "text": "Bilbo Baggins does not count against the hero limit and cannot gain resources from non-treasure cards.\nThe first player gains control of Bilbo Baggins.\nAction: Spend 1 Baggins resource to search your deck for a treasure card and add it to your hand.\nIf Bilbo Baggins leaves play, the players have lost the game.",
-    "flavor": null,
     "textc": "Bilbo Baggins does not count against the hero limit and cannot gain resources from non-treasure cards.\nThe first player gains control of Bilbo Baggins.\nAction: Spend 1 Baggins resource to search your deck for a treasure card and add it to your hand.\nIf Bilbo Baggins leaves play, the players have lost the game.",
     "name_norm": "Bilbo Baggins",
-    "octgn": "4e61b160-2104-497f-9977-4b353e54fbb7"
+    "octgn": "4e61b160-2104-497f-9977-4b353e54fbb7",
+    "categories": ""
   },
   {
     "name": "Balin",
@@ -9345,7 +9558,8 @@
     "flavor": "`Well, it is the first time that even a mouse has crept along carefully and quietly under my very nose and not been spotted.` -The Hobbit",
     "textc": "Response: Pay 1 resource from Balin's resource pool to cancel a shadow effect just triggered during an attack. Then, deal the attacking enemy another shadow card. (Limit once per attack.)",
     "name_norm": "Balin",
-    "octgn": "bf2cb5a8-2ec6-4366-89f6-7e3010686a85"
+    "octgn": "bf2cb5a8-2ec6-4366-89f6-7e3010686a85",
+    "categories": "Shadow Control"
   },
   {
     "name": "Bard the Bowman",
@@ -9367,7 +9581,8 @@
     "flavor": "Now he shot with a great yew bow, till all his arrows but one were spent. -The Hobbit",
     "textc": "Ranged.\nWhen Bard the Bowman makes a ranged attack, the enemy he attacks gets -2 Defense until the end of the phase.",
     "name_norm": "Bard the Bowman",
-    "octgn": "e2cf87be-ccdc-48e9-8127-57bee67d4a0c"
+    "octgn": "e2cf87be-ccdc-48e9-8127-57bee67d4a0c",
+    "categories": ""
   },
   {
     "name": "Oin",
@@ -9389,7 +9604,8 @@
     "flavor": "Dwarves can make fire almost anywhere out of almost anything, wind or no wind... -The Hobbit",
     "textc": "While you control at least 5 Dwarf characters, Oin gets +1 Attack and gains the Tactics resource icon.",
     "name_norm": "Oin",
-    "octgn": "b21a2af5-7443-4630-9503-1b334ae51c6e"
+    "octgn": "b21a2af5-7443-4630-9503-1b334ae51c6e",
+    "categories": ""
   },
   {
     "name": "Bombur",
@@ -9411,10 +9627,11 @@
     "flavor": "`Bombur is fattest and will do for two, he had better come alone and last.` -Gandalf, The Hobbit",
     "textc": "When counting the number of Dwarf characters you control, Bombur counts as two.",
     "name_norm": "Bombur",
-    "octgn": "66f66c2e-36e7-4d97-aebb-1ca413f9edeb"
+    "octgn": "66f66c2e-36e7-4d97-aebb-1ca413f9edeb",
+    "categories": ""
   },
   {
-    "name": "Glóin",
+    "name": "Gl\u00f3in",
     "type": "2ally",
     "sphere": "1leadership",
     "cost": 3,
@@ -9429,11 +9646,12 @@
     "unique": true,
     "traits": " Dwarf.",
     "keywords": "",
-    "text": "While you control at least 5 Dwarf characters, Glóin gains: 'Response: After you play Glóin from your hand, choose a hero. Add 2 resources to that hero's resource pool.'",
-    "flavor": "Glóin lit several more torches, and then they all crept out, one by one... - The Hobbit ",
-    "textc": "While you control at least 5 Dwarf characters, Glóin gains: 'Response: After you play Glóin from your hand, choose a hero. Add 2 resources to that hero's resource pool.'",
+    "text": "While you control at least 5 Dwarf characters, Gl\u00f3in gains: 'Response: After you play Gl\u00f3in from your hand, choose a hero. Add 2 resources to that hero's resource pool.'",
+    "flavor": "Gl\u00f3in lit several more torches, and then they all crept out, one by one... - The Hobbit ",
+    "textc": "While you control at least 5 Dwarf characters, Gl\u00f3in gains: 'Response: After you play Gl\u00f3in from your hand, choose a hero. Add 2 resources to that hero's resource pool.'",
     "name_norm": "Gloin",
-    "octgn": "6778eb01-6b07-4dbe-87f1-e854ab548813"
+    "octgn": "6778eb01-6b07-4dbe-87f1-e854ab548813",
+    "categories": "Resource Acceleration"
   },
   {
     "name": "Bifur",
@@ -9455,7 +9673,8 @@
     "flavor": "`My cousins! Bombur and Bofur - we have forgotten them, they are down in the valley!` -The Hobbit",
     "textc": "While you control at least 5 Dwarf characters, Bifur gains: 'Response: After you play Bifur from your hand, draw 2 cards.'",
     "name_norm": "Bifur",
-    "octgn": "c4b959f5-92a9-4f46-8656-f9da08a5cb86"
+    "octgn": "c4b959f5-92a9-4f46-8656-f9da08a5cb86",
+    "categories": "Card Draw"
   },
   {
     "name": "Dwalin",
@@ -9474,10 +9693,10 @@
     "traits": " Dwarf.",
     "keywords": "Sentinel.",
     "text": "While you control at least 5 Dwarf characters, lower the cost to play Dwalin by 2.",
-    "flavor": null,
     "textc": "Sentinel.\nWhile you control at least 5 Dwarf characters, lower the cost to play Dwalin by 2.",
     "name_norm": "Dwalin",
-    "octgn": "c66638a7-95ae-4913-bf11-2e8dcf8d6104"
+    "octgn": "c66638a7-95ae-4913-bf11-2e8dcf8d6104",
+    "categories": ""
   },
   {
     "name": "Straight Shot",
@@ -9495,7 +9714,8 @@
     "flavor": "In it smote and vanished, barb, shaft and feather, so fierce was its flight. -The Hobbit",
     "textc": "Action: Exhaust a Weapon attachment to choose a non-unique enemy with 0 Defense. Discard the chosen enemy.",
     "name_norm": "Straight Shot",
-    "octgn": "c2a79823-e4f9-4449-b467-5916d7e58979"
+    "octgn": "c2a79823-e4f9-4449-b467-5916d7e58979",
+    "categories": ""
   },
   {
     "name": "Desperate Alliance",
@@ -9513,7 +9733,8 @@
     "flavor": "`Come!` called Gandalf. `There is yet time for council.` -The Hobbit",
     "textc": "Action: Choose a hero you control. Until the end of the phase, give control of that hero and all resources in that hero's resource pool to another player. (Limit 1 per phase.)",
     "name_norm": "Desperate Alliance",
-    "octgn": "7465c18b-440e-4a90-8ac0-c50c0de03b5d"
+    "octgn": "7465c18b-440e-4a90-8ac0-c50c0de03b5d",
+    "categories": ""
   },
   {
     "name": "Ravens of the Mountain",
@@ -9531,7 +9752,8 @@
     "flavor": "As they worked the ravens brought them constant tidings. -The Hobbit",
     "textc": "Action: Exhaust a hero you control to shuffle the encounter deck and look at its top card. Place progress tokens on the current quest equal to the revealed card's Threat. Then, put that card back on top of the encounter deck.",
     "name_norm": "Ravens of the Mountain",
-    "octgn": "6d442a61-e9e9-4729-bac1-da3d76af6afa"
+    "octgn": "6d442a61-e9e9-4729-bac1-da3d76af6afa",
+    "categories": ""
   },
   {
     "name": "To me! O my kinsfolk!",
@@ -9549,7 +9771,8 @@
     "flavor": "Out leapt the King under the Mountain, and his companions followed him. -The Hobbit",
     "textc": "Action: If you control at least 1 Dwarf hero, put a Dwarf ally from your discard pile into play under your control. Put that ally on the bottom of your deck at the end of the phase.",
     "name_norm": "To me O my kinsfolk",
-    "octgn": "16ae4f56-d8bb-41b8-a992-1da3b6ec1fdb"
+    "octgn": "16ae4f56-d8bb-41b8-a992-1da3b6ec1fdb",
+    "categories": ""
   },
   {
     "name": "The Lucky Number",
@@ -9564,10 +9787,10 @@
     "traits": "",
     "keywords": "",
     "text": "Action: Choose a character in play (other than Bilbo Baggins). Add Bilbo Baggins' total Willpower, Attack, and Defense to that character's Willpower, Attack, and Defense respectively until the end of the phase.",
-    "flavor": null,
     "textc": "Action: Choose a character in play (other than Bilbo Baggins). Add Bilbo Baggins' total Willpower, Attack, and Defense to that character's Willpower, Attack, and Defense respectively until the end of the phase.",
     "name_norm": "The Lucky Number",
-    "octgn": "65407141-e013-4d1c-8f70-4328e707d0cc"
+    "octgn": "65407141-e013-4d1c-8f70-4328e707d0cc",
+    "categories": ""
   },
   {
     "name": "Great Yew Bow",
@@ -9582,10 +9805,10 @@
     "traits": " Item. Weapon.",
     "keywords": "Restricted.",
     "text": "Attach to a hero with printed Ranged keyword.\nCombat Action: Choose an enemy in the staging area. Exhaust Great Yew Bow and attached hero to make a ranged attack against that enemy. Declare attached hero as the attacker. No other attackers can be declared for this attack.",
-    "flavor": null,
     "textc": "Restricted.\nAttach to a hero with printed Ranged keyword.\nCombat Action: Choose an enemy in the staging area. Exhaust Great Yew Bow and attached hero to make a ranged attack against that enemy. Declare attached hero as the attacker. No other attackers can be declared for this attack.",
     "name_norm": "Great Yew Bow",
-    "octgn": "833664a0-6bab-4e93-b5f1-88e7b6456569"
+    "octgn": "833664a0-6bab-4e93-b5f1-88e7b6456569",
+    "categories": ""
   },
   {
     "name": "Black Arrow",
@@ -9604,10 +9827,11 @@
     "flavor": "`I have saved you to the last...` -Bard, The Hobbit",
     "textc": "Victory 1.\nLimit 1 per deck. Attach to a hero with Ranged.\nResponse: After attached hero declares an attack, add Black Arrow to the victory display to give attached hero +5 Attack for this attack.",
     "name_norm": "Black Arrow",
-    "octgn": "ae16236d-886e-4f65-9129-5ead1d373bfe"
+    "octgn": "ae16236d-886e-4f65-9129-5ead1d373bfe",
+    "categories": "Attack Bonus"
   },
   {
-    "name": "Thrór's Key",
+    "name": "Thr\u00f3r's Key",
     "type": "3attachment",
     "sphere": "3spirit",
     "cost": 1,
@@ -9622,7 +9846,8 @@
     "flavor": "`The key that went with the map! Try it now while there is still time!` -Bilbo, The Hobbit",
     "textc": "Attacht to a hero.\nResponse: After a location is added to the staging area, attach Thror's Key to that location. While attached to a location, Thror's Key gains: 'Treat attached location's printed text box as blank, except for traits.'",
     "name_norm": "Thror's Key",
-    "octgn": "f4490261-317e-4e9e-9440-a5c58dcddcbf"
+    "octgn": "f4490261-317e-4e9e-9440-a5c58dcddcbf",
+    "categories": ""
   },
   {
     "name": "Expert Treasure-hunter",
@@ -9637,10 +9862,10 @@
     "traits": " Skill.",
     "keywords": "",
     "text": "Attach to a hero. Limit 1 per hero.\nResponse: After attached hero quests successfully, name a card type and discard the top card of your deck. If the discarded card is the named type, take it into your hand.",
-    "flavor": null,
     "textc": "Attach to a hero. Limit 1 per hero.\nResponse: After attached hero quests successfully, name a card type and discard the top card of your deck. If the discarded card is the named type, take it into your hand.",
     "name_norm": "Expert Treasure-hunter",
-    "octgn": "2d550e71-f2a6-41f2-8aac-4533a965eb71"
+    "octgn": "2d550e71-f2a6-41f2-8aac-4533a965eb71",
+    "categories": "Card Draw"
   },
   {
     "name": "King Under the Mountain",
@@ -9658,7 +9883,8 @@
     "flavor": "`Long ago in my grandfather Thror's time our family was driven out of the far North, and came back with all their wealth and tools to this Mountain on the map.` -Thorin, The Hobbit",
     "textc": "Attach to a Dwarf hero.\nAction: Exhaust King Under the Mountain to look at the top 2 cards of your deck. Add 1 to your hand and discard the other.",
     "name_norm": "King Under the Mountain",
-    "octgn": "9152834a-5355-42ba-9592-1a3c1940d1a8"
+    "octgn": "9152834a-5355-42ba-9592-1a3c1940d1a8",
+    "categories": "Card Draw"
   },
   {
     "name": "Frodo Baggins",
@@ -9680,7 +9906,8 @@
     "flavor": "`I will take the Ring,` he said, `though I do not know the way.` -The Fellowship of the Ring",
     "textc": "Response: Spend 1 Fellowship resource and exhaust The One Ring to cancel the effect of an encounter card just revealed from the encounter deck. Shuffle that card back into the encounter deck and reveal another encounter card.",
     "name_norm": "Frodo Baggins",
-    "octgn": "3217a119-6b86-47dd-b451-c5e45be3f874"
+    "octgn": "3217a119-6b86-47dd-b451-c5e45be3f874",
+    "categories": ""
   },
   {
     "name": "Sam Gamgee",
@@ -9702,7 +9929,8 @@
     "flavor": "`I'm going with him...and if any of those Black Riders try to stop him, they'll have Sam Gamgee to reckon with` -The Fellowship of the Ring",
     "textc": "Response: After you engage an enemy with a higher engagement cost than your threat, ready Sam Gamgee. He gets +1 Willpower, +1 Attack and +1 Defense until the end of the round.",
     "name_norm": "Sam Gamgee",
-    "octgn": "4124136c-8c86-4f86-830c-94c8c76df161"
+    "octgn": "4124136c-8c86-4f86-830c-94c8c76df161",
+    "categories": "Defense Bonus"
   },
   {
     "name": "Merry",
@@ -9724,7 +9952,8 @@
     "flavor": "`You can trust us to stick to you through thick and thin to the bitter end` -The Fellowship of the Ring",
     "textc": "Merry gets +1 Attack for each Hobbit hero you control.\nResponse: After Merry participates in an attack that destroys an enemy, ready another character that participated in that attack.",
     "name_norm": "Merry",
-    "octgn": "052b1f85-8b9c-4bb0-a735-bdbd5ac1b2c4"
+    "octgn": "052b1f85-8b9c-4bb0-a735-bdbd5ac1b2c4",
+    "categories": "Attack Bonus, Readying"
   },
   {
     "name": "Pippin",
@@ -9743,10 +9972,11 @@
     "traits": " Hobbit.",
     "keywords": "",
     "text": "Each enemy in play gets +1 engagement cost for each Hobbit hero you control.\nResponse: After you engage an enemy with an engagement cost higher than your threat, draw a card.",
-    "flavor": "`We Hobbits ought to stick together, and we will`\r\n-The Fellowship of the Ring",
+    "flavor": "`We Hobbits ought to stick together, and we will`\n-The Fellowship of the Ring",
     "textc": "Each enemy in play gets +1 engagement cost for each Hobbit hero you control.\nResponse: After you engage an enemy with an engagement cost higher than your threat, draw a card.",
     "name_norm": "Pippin",
-    "octgn": "ce96b767-c569-48b8-a998-d8009b0143c7"
+    "octgn": "ce96b767-c569-48b8-a998-d8009b0143c7",
+    "categories": "Card Draw"
   },
   {
     "name": "Fatty Bolger",
@@ -9768,7 +9998,8 @@
     "flavor": "`I only hope that you do not need rescuing before the day is out` -The Fellowship of the Ring",
     "textc": "Action: Exhaust Fatty Bolger to choose an enemy in the staging area and raise your threat by that enemy's Threat. Until the end of the phase, that enemy does not contribute its Threat. (Limit once per round.)",
     "name_norm": "Fatty Bolger",
-    "octgn": "5d75d4dd-7300-43d7-87f2-963271c9c904"
+    "octgn": "5d75d4dd-7300-43d7-87f2-963271c9c904",
+    "categories": ""
   },
   {
     "name": "Bill the Pony",
@@ -9790,7 +10021,8 @@
     "flavor": "`He gave me a look as plain as Mr. Pippin could speak it: if you don't let me go with you, Sam, I'll follow on my own` -Sam Gamgee, The Fellowship of the Ring",
     "textc": "Cannot have attachments.\nLower the cost to play Bill the Pony by 2 if you control Sam Gamgee.\nEach Hobbit character gets +1 hit point.",
     "name_norm": "Bill the Pony",
-    "octgn": "1f7fc118-94a7-48a0-bd0c-9c15a36ddc23"
+    "octgn": "1f7fc118-94a7-48a0-bd0c-9c15a36ddc23",
+    "categories": "Hit Point Bonus"
   },
   {
     "name": "Barliman Butterbur",
@@ -9812,7 +10044,8 @@
     "flavor": "`But spooks or no spooks, they won't get in The Prancing Pony so easy.` -The Fellowship of the Ring",
     "textc": "If each hero you control has the Hobbit trait, damage from undefended attacks against you may be assigned to Barliman Butterbur.",
     "name_norm": "Barliman Butterbur",
-    "octgn": "77f58774-86e7-4449-b31e-3833700b3e60"
+    "octgn": "77f58774-86e7-4449-b31e-3833700b3e60",
+    "categories": ""
   },
   {
     "name": "Farmer Maggot",
@@ -9834,7 +10067,8 @@
     "flavor": "`It is lucky for you that I know you. I was going out to set my dogs on any strangers.` -The Fellowship of the Ring",
     "textc": "Response: After Farmer Maggot enters play, deal 1 damage to an enemy engaged with you. (Deal 2 damage instead if that enemy's engagement cost is higher than your threat.)",
     "name_norm": "Farmer Maggot",
-    "octgn": "9d8ccd1a-48d3-4123-bcca-3c0ab88347ec"
+    "octgn": "9d8ccd1a-48d3-4123-bcca-3c0ab88347ec",
+    "categories": "Direct Damage"
   },
   {
     "name": "Halfling Determination",
@@ -9852,7 +10086,8 @@
     "flavor": "`I have something to do before the end, and it lies ahead, not in the Shire. I must see it through, sir, if you understand me.` -Sam Gamgee, The Fellowship of the Ring",
     "textc": "Action: Choose a Hobbit character. That character gets +2 Willpower, +2 Attack and +2 Defense until the end of the phase.",
     "name_norm": "Halfling Determination",
-    "octgn": "8e7e5c8d-0ea4-46df-ae38-d8d2fee7ca8b"
+    "octgn": "8e7e5c8d-0ea4-46df-ae38-d8d2fee7ca8b",
+    "categories": "Attack Bonus, Defense Bonus"
   },
   {
     "name": "Smoke Rings",
@@ -9870,7 +10105,8 @@
     "flavor": "...he smoked and blew smoke-rings with the same vigour and delight...-The Fellowship of the Ring",
     "textc": "Action: Reduce your threat by 1 for each Pipe you control. Each hero with a Pipe attachment gets +1 Willpower until the end of the phase.",
     "name_norm": "Smoke Rings",
-    "octgn": "9418c634-54c6-47de-9aae-798038a4a35b"
+    "octgn": "9418c634-54c6-47de-9aae-798038a4a35b",
+    "categories": "Threat Control"
   },
   {
     "name": "Take No Notice",
@@ -9888,7 +10124,8 @@
     "flavor": "...they made no noise that even hobbits would hear. Event the wild things in the fields and woods hardly noticed their passing. -The Fellowship of the Ring",
     "textc": "Lower the cost play Take No Notice by 1 for each Hobbit or Ranger hero you control.\nAction: Add 5 to each enemy's engagement cost until the end of the round.",
     "name_norm": "Take No Notice",
-    "octgn": "768ae041-2d15-44a3-a928-62838536a160"
+    "octgn": "768ae041-2d15-44a3-a928-62838536a160",
+    "categories": ""
   },
   {
     "name": "Frodo's Intuition",
@@ -9906,7 +10143,8 @@
     "flavor": "`I wonder if that is Gandalf coming after us` said Frodo, but even as he said it, he had a feeling that it was not so... -The Fellowship of the Ring",
     "textc": "Action: Each hero you control gets +1 Willpower until the end of the round. Draw 1 card for each Hobbit hero you control.",
     "name_norm": "Frodo's Intuition",
-    "octgn": "96350b97-5c68-4033-bb2f-4305696a7ae7"
+    "octgn": "96350b97-5c68-4033-bb2f-4305696a7ae7",
+    "categories": ""
   },
   {
     "name": "Hobbit Cloak",
@@ -9924,7 +10162,8 @@
     "flavor": "In their dark cloaks they were invisible as if they all had magic rings. -The Fellowship of the Ring",
     "textc": "Attach to a Hobbit hero. Limit 1 per hero.\nAttached hero gets +2 Defense while defending against an attack by an enemy with an engagement cost higher than your threat.",
     "name_norm": "Hobbit Cloak",
-    "octgn": "8e49ea86-375a-472e-b497-16a1164ae27f"
+    "octgn": "8e49ea86-375a-472e-b497-16a1164ae27f",
+    "categories": "Defense Bonus"
   },
   {
     "name": "Dagger of Westernesse",
@@ -9939,10 +10178,11 @@
     "traits": " Artifact. Item. Weapon.",
     "keywords": "Restricted.",
     "text": "Attach to a hero.\nAttached hero gets +1 Attack (+2 Attack instead if attacking an enemy with an engagement cost higher than your threat).",
-    "flavor": "...these blades were forged many long years ago by Men of Westernesse: they were foes of the Dark Lord...\r\n-The Fellowship of the Ring",
+    "flavor": "...these blades were forged many long years ago by Men of Westernesse: they were foes of the Dark Lord...\n-The Fellowship of the Ring",
     "textc": "Restricted.\nAttach to a hero.\nAttached hero gets +1 Attack (+2 Attack instead if attacking an enemy with an engagement cost higher than your threat).",
     "name_norm": "Dagger of Westernesse",
-    "octgn": "418e6de7-af19-4ea7-bfbe-2a02838c6de4"
+    "octgn": "418e6de7-af19-4ea7-bfbe-2a02838c6de4",
+    "categories": "Attack Bonus"
   },
   {
     "name": "Hobbit Pipe",
@@ -9957,10 +10197,11 @@
     "traits": " Item. Pipe.",
     "keywords": "",
     "text": "Attach to a Hobbit character. Limit 1 per character.\nResponse: After your threat is reduced by an event card effect, exhaust Hobbit Pipe to draw a card.",
-    "flavor": "But even the Dúnedain of Gondor allow us this credit: Hobbits first put it into pipes. Not even the Wizards first thought of that before we did. -The Fellowship of the Ring",
+    "flavor": "But even the D\u00fanedain of Gondor allow us this credit: Hobbits first put it into pipes. Not even the Wizards first thought of that before we did. -The Fellowship of the Ring",
     "textc": "Attach to a Hobbit character. Limit 1 per character.\nResponse: After your threat is reduced by an event card effect, exhaust Hobbit Pipe to draw a card.",
     "name_norm": "Hobbit Pipe",
-    "octgn": "9c455b1a-a2d4-44f7-a9d3-9a3134c21a2a"
+    "octgn": "9c455b1a-a2d4-44f7-a9d3-9a3134c21a2a",
+    "categories": "Card Draw"
   },
   {
     "name": "Elf-stone",
@@ -9975,10 +10216,11 @@
     "traits": " Artifact. Item.",
     "keywords": "",
     "text": "Attach to the active location. Attached location gets +1 quest point.\nResponse: After attached location leaves play as an explored location, the first player puts 1 ally into play from his hand.",
-    "flavor": "`It is a beryl, an elf-stone. Whether it was set there, or let fall by chance, I cannot say, but it brings hope to me`\r\n-Aragorn, The Fellowship of the Ring",
+    "flavor": "`It is a beryl, an elf-stone. Whether it was set there, or let fall by chance, I cannot say, but it brings hope to me`\n-Aragorn, The Fellowship of the Ring",
     "textc": "Attach to the active location. Attached location gets +1 quest point.\nResponse: After attached location leaves play as an explored location, the first player puts 1 ally into play from his hand.",
     "name_norm": "Elf-stone",
-    "octgn": "9bb32f2c-29fb-43ba-b7ba-2227b28f7b58"
+    "octgn": "9bb32f2c-29fb-43ba-b7ba-2227b28f7b58",
+    "categories": ""
   },
   {
     "name": "Frodo Baggins",
@@ -10000,7 +10242,8 @@
     "flavor": "`But there is more about you now than appears on the surface.` -Bilbo, The Fellowship of the Ring",
     "textc": "Response: After Frodo Baggins exhausts to defend an attack, exhaust The One Ring and spend 1 Fellowship resource to target the attacking enemy. Then, this attack deals no damage and each player raises his threat by 2.",
     "name_norm": "Frodo Baggins",
-    "octgn": "f9196cda-8f50-4cc5-9aad-1c56cb677bca"
+    "octgn": "f9196cda-8f50-4cc5-9aad-1c56cb677bca",
+    "categories": ""
   },
   {
     "name": "Gandalf",
@@ -10022,7 +10265,8 @@
     "flavor": "`I am a servant of the Secret Fire, wielder of the flame of Anor.` -The Fellowship of the Ring",
     "textc": "Play with the top card of your deck faceup. Once per phase, you may play the top card of your deck as if it was in your hand. When playing a card this way, Gandalf is considered to have the printed Leadership, Lore, Tactics, and Spirit icons.",
     "name_norm": "Gandalf",
-    "octgn": "3e055edf-4540-4cf1-94ce-afbf5fc28f82"
+    "octgn": "3e055edf-4540-4cf1-94ce-afbf5fc28f82",
+    "categories": ""
   },
   {
     "name": "Galadriel",
@@ -10041,10 +10285,10 @@
     "traits": " Noldor. Noble.",
     "keywords": "",
     "text": "At the end of the round, discard Galadriel from play.\nResponse: After you play Galadriel from your hand, search the top 5 cards of your deck for an attachment of cost 3 or less and put it into play. Put the remaining cards back in any order.",
-    "flavor": null,
     "textc": "At the end of the round, discard Galadriel from play.\nResponse: After you play Galadriel from your hand, search the top 5 cards of your deck for an attachment of cost 3 or less and put it into play. Put the remaining cards back in any order.",
     "name_norm": "Galadriel",
-    "octgn": "3d09a998-9ad0-4b98-9c42-50c4226cc73b"
+    "octgn": "3d09a998-9ad0-4b98-9c42-50c4226cc73b",
+    "categories": "Card Draw"
   },
   {
     "name": "Boromir",
@@ -10063,10 +10307,10 @@
     "traits": " Gondor. Warrior.",
     "keywords": "",
     "text": "Boromir gets +2 Defense while defending against an enemy with an engagement cost higher than your threat.\nResponse: After Boromir takes any amount of damage, ready him.",
-    "flavor": null,
     "textc": "Boromir gets +2 Defense while defending against an enemy with an engagement cost higher than your threat.\nResponse: After Boromir takes any amount of damage, ready him.",
     "name_norm": "Boromir",
-    "octgn": "36b26228-1c01-4064-a109-d110e00d8e4b"
+    "octgn": "36b26228-1c01-4064-a109-d110e00d8e4b",
+    "categories": "Readying, Defense Bonus"
   },
   {
     "name": "Elrond",
@@ -10085,10 +10329,10 @@
     "traits": " Noldor. Healer.",
     "keywords": "",
     "text": "At the end of the round, discard Elrond from play.\nResponse: After Elrond enters play, choose one: heal all damage on a hero, discard a Condition attachment, or each player draws 1 card.",
-    "flavor": null,
     "textc": "At the end of the round, discard Elrond from play.\nResponse: After Elrond enters play, choose one: heal all damage on a hero, discard a Condition attachment, or each player draws 1 card.",
     "name_norm": "Elrond",
-    "octgn": "638638f0-8177-410a-bce8-9e2bbf5ad81f"
+    "octgn": "638638f0-8177-410a-bce8-9e2bbf5ad81f",
+    "categories": "Card Draw, Condition Control, Healing"
   },
   {
     "name": "Bilbo Baggins",
@@ -10110,7 +10354,8 @@
     "flavor": "`Elves may thrive on speech alone, and Dwarves endure great weariness, but I am an old Hobbit, and I miss my meal at noon.` -The Fellowship of the Ring",
     "textc": "Response: After Bilbo Baggins enters play, search your deck for a Pipe attachment and add it to your hand. Shuffle your deck.",
     "name_norm": "Bilbo Baggins",
-    "octgn": "e02cc17b-80e4-4a8f-ba55-1df74aac816d"
+    "octgn": "e02cc17b-80e4-4a8f-ba55-1df74aac816d",
+    "categories": "Card Search"
   },
   {
     "name": "Flame of Anor",
@@ -10128,7 +10373,8 @@
     "flavor": "`You cannot pass!` -Gandalf, The Fellowship of the Ring",
     "textc": "Victory 1.\nAction: Add Flame of Anor to the victory display and discard the top card of your deck to ready an Istari character you control. That character gets +X Attack until the end of the phase where X is the discarded card's cost.",
     "name_norm": "Flame of Anor",
-    "octgn": "8a5ff815-56cf-4d5f-a649-a111e736a9f1"
+    "octgn": "8a5ff815-56cf-4d5f-a649-a111e736a9f1",
+    "categories": ""
   },
   {
     "name": "Gandalf's Staff",
@@ -10146,7 +10392,8 @@
     "flavor": "...he held his staff aloft, and from its tip there came a feint radiance. -The Fellowship of the Ring",
     "textc": "Restricted.\nAttach to Gandalf.\nAction: Exhaust Gandalf's Staff to (choose one): choose a player to draw 1 card, add 1 resource to a hero's resource pool, or discard a shadow card from a non-unique enemy.",
     "name_norm": "Gandalf's Staff",
-    "octgn": "02e56cef-e78d-4dbd-bd4d-6ec43e4b1d2b"
+    "octgn": "02e56cef-e78d-4dbd-bd4d-6ec43e4b1d2b",
+    "categories": "Card Draw, Resource Acceleration, Shadow Control"
   },
   {
     "name": "Wizard Pipe",
@@ -10164,7 +10411,8 @@
     "flavor": "...there was a long silence, broken only by the soft puffs of Gandalf's pipe, as he blew white smoke-rings out of the window. -The Fellowship of the Ring",
     "textc": "Attach to an Istari character. Limit 1 per character.\nAction: Exhaust Wizard Pipe to exchange a card in your hand with the top card of your deck.",
     "name_norm": "Wizard Pipe",
-    "octgn": "428256aa-e03e-4f57-9b38-b8f7b5f17578"
+    "octgn": "428256aa-e03e-4f57-9b38-b8f7b5f17578",
+    "categories": ""
   },
   {
     "name": "Fellowship of the Ring",
@@ -10179,10 +10427,10 @@
     "traits": " Fellowship.",
     "keywords": "",
     "text": "Attach to the Ring-bearer.\nEach hero gets +1 Willpower.\nForced: After a character is destroyed, discard Fellowship of the Ring.",
-    "flavor": null,
     "textc": "Attach to the Ring-bearer.\nEach hero gets +1 Willpower.\nForced: After a character is destroyed, discard Fellowship of the Ring.",
     "name_norm": "Fellowship of the Ring",
-    "octgn": "d5f09d24-be50-4958-b0d0-41b1ad09b7af"
+    "octgn": "d5f09d24-be50-4958-b0d0-41b1ad09b7af",
+    "categories": ""
   },
   {
     "name": "Aragorn",
@@ -10198,16 +10446,17 @@
     "no": 1,
     "img": "http://www.cardgamedb.com/forums/uploads/lotr/MEC45_1.jpg",
     "unique": true,
-    "traits": " Dúnedain. Noble. Ranger.",
+    "traits": " D\u00fanedain. Noble. Ranger.",
     "keywords": "",
     "text": "The first player gains control of Aragorn. If Aragorn leaves play, the players lose the game.\nAction: Spend 2 resources from Aragorn's resource pool to ready a hero.",
-    "flavor": "`I am Aragorn son of Arathorn and am called Elessar, the Elfstone, Dúnedain, the heir of Isildur Elendil's son of Gondor` -The Two Towers",
+    "flavor": "`I am Aragorn son of Arathorn and am called Elessar, the Elfstone, D\u00fanedain, the heir of Isildur Elendil's son of Gondor` -The Two Towers",
     "textc": "The first player gains control of Aragorn. If Aragorn leaves play, the players lose the game.\nAction: Spend 2 resources from Aragorn's resource pool to ready a hero.",
     "name_norm": "Aragorn",
-    "octgn": "f5178135-1485-43c5-9660-99232a4cdca8"
+    "octgn": "f5178135-1485-43c5-9660-99232a4cdca8",
+    "categories": ""
   },
   {
-    "name": "Théoden",
+    "name": "Th\u00e9oden",
     "type": "1hero",
     "sphere": "3spirit",
     "cost": 12,
@@ -10223,10 +10472,11 @@
     "traits": " Rohan. Noble. Warrior.",
     "keywords": "Sentinel",
     "text": "Reduce the cost of the first Rohan ally you play from your hand each round by 1 (to a minimum of 0).",
-    "flavor": "`Arise now, arise, Riders of Théoden!` -The Two Towers",
+    "flavor": "`Arise now, arise, Riders of Th\u00e9oden!` -The Two Towers",
     "textc": "Sentinel.\nReduce the cost of the first Rohan ally you play from you hand each round by 1 (to a minimum of 0).",
     "name_norm": "Theoden",
-    "octgn": "f3d88160-30f2-4b8b-9e83-c42e62851bbc"
+    "octgn": "f3d88160-30f2-4b8b-9e83-c42e62851bbc",
+    "categories": ""
   },
   {
     "name": "Treebeard",
@@ -10248,7 +10498,8 @@
     "flavor": "`I am not altogether on anybody's side, because nobody is altogether on my side...` -The Two Towers",
     "textc": "Cannot have restricted attachments.\nAction: Deal 1 damage to Treebeard to give him +1 Willpower and +1 Attack until the end of the phase. (Limit 5 times per phase.)",
     "name_norm": "Treebeard",
-    "octgn": "94f6738a-c946-4415-9b38-0ce3a443fa33"
+    "octgn": "94f6738a-c946-4415-9b38-0ce3a443fa33",
+    "categories": ""
   },
   {
     "name": "Gimli",
@@ -10270,7 +10521,8 @@
     "flavor": "`Give me a row of orc-necks and room to swing and all weariness will fall from me!` -The Two Towers",
     "textc": "Sentinel.\nResponse: After an enemy is revealed from the encounter deck, ready Gimli.",
     "name_norm": "Gimli",
-    "octgn": "6a9ff9c1-64d2-4ed5-a793-9e93e8d605b7"
+    "octgn": "6a9ff9c1-64d2-4ed5-a793-9e93e8d605b7",
+    "categories": ""
   },
   {
     "name": "Legolas",
@@ -10292,7 +10544,8 @@
     "flavor": "`He stands not alone,` said Legolas, bending his bow and fitting an arrow with hands that moved quicker than sight. -The Two Towers",
     "textc": "Ranged.\nResponse: After Legolas participates in an attack that destroys an enemy, draw 1 card.",
     "name_norm": "Legolas",
-    "octgn": "9825aa22-f197-4320-972d-e2487197d989"
+    "octgn": "9825aa22-f197-4320-972d-e2487197d989",
+    "categories": "Card Draw"
   },
   {
     "name": "Quickbeam",
@@ -10314,10 +10567,11 @@
     "flavor": "`I am Bregalad, that is Quickbeam in your language. But it is only a nickname, of course.` -The Two Towers",
     "textc": "Cannot have restricted attachments. Enters play exhausted.\nResponse: After Quickbeam enters play, deal 1 damage to him to ready him.",
     "name_norm": "Quickbeam",
-    "octgn": "f37fc371-5a6e-4a24-85a1-2afef11c6841"
+    "octgn": "f37fc371-5a6e-4a24-85a1-2afef11c6841",
+    "categories": "Readying"
   },
   {
-    "name": "Háma",
+    "name": "H\u00e1ma",
     "type": "2ally",
     "sphere": "3spirit",
     "cost": 3,
@@ -10332,11 +10586,12 @@
     "unique": true,
     "traits": " Rohan. Warrior.",
     "keywords": "",
-    "text": "Combat Action: Ready Háma. He gets +3 Defense until the end of the phase. At the end of the phase, discard Háma. (Limit once per round.)",
-    "flavor": "`I am the doorward of Théoden,` he said. `Háma is my name` -The Two Towers",
-    "textc": "Combat Action: Ready Háma. He gets +3 Defense until the end of the phase. At the end of the phase, discard Háma. (Limit once per round.)",
+    "text": "Combat Action: Ready H\u00e1ma. He gets +3 Defense until the end of the phase. At the end of the phase, discard H\u00e1ma. (Limit once per round.)",
+    "flavor": "`I am the doorward of Th\u00e9oden,` he said. `H\u00e1ma is my name` -The Two Towers",
+    "textc": "Combat Action: Ready H\u00e1ma. He gets +3 Defense until the end of the phase. At the end of the phase, discard H\u00e1ma. (Limit once per round.)",
     "name_norm": "Hama",
-    "octgn": "adc3e6f6-da67-4cc1-9767-8e87dfc91b99"
+    "octgn": "adc3e6f6-da67-4cc1-9767-8e87dfc91b99",
+    "categories": "Defense Bonus"
   },
   {
     "name": "Arod",
@@ -10354,7 +10609,8 @@
     "flavor": "`A smaller and lighter horse, but restive and fiery, was brought to Legolas. Arod was his name.` -The Two Towers",
     "textc": "Attach to a hero or Legolas.\nResponse: After attached character participates in an attack that destroys an enemy, exhaust Arod to place 1 progress token on any location.",
     "name_norm": "Arod",
-    "octgn": "6646bb07-0b44-4051-94a7-39c600b38481"
+    "octgn": "6646bb07-0b44-4051-94a7-39c600b38481",
+    "categories": ""
   },
   {
     "name": "Ent Draught",
@@ -10372,7 +10628,8 @@
     "flavor": "The effect of the draught began at the toes, and rose steadily through every limb, bringing refreshment and vigour as it coursed upwards, right to the tips of the hair. -The Two Towers",
     "textc": "Play only if you control at least 1 Ent character.\nAttach to a character. Limit 1 per character.\nAttached character gets +2 hit points.",
     "name_norm": "Ent Draught",
-    "octgn": "b86ba0f8-11f9-4694-b421-17b683bd4325"
+    "octgn": "b86ba0f8-11f9-4694-b421-17b683bd4325",
+    "categories": "Hit Point Bonus"
   },
   {
     "name": "Herugrim",
@@ -10386,11 +10643,12 @@
     "unique": true,
     "traits": " Item. Weapon.",
     "keywords": "Restricted.",
-    "text": "Attach to a Rohan hero. Restricted.\n Reduce the cost to play Herugrim on Théoden by 1.\nRespone: After attached hero is declared an an attacker, exhaust Herugrim to add attached hero's Willpower to its Attack for this attack.",
+    "text": "Attach to a Rohan hero. Restricted.\n Reduce the cost to play Herugrim on Th\u00e9oden by 1.\nRespone: After attached hero is declared an an attacker, exhaust Herugrim to add attached hero's Willpower to its Attack for this attack.",
     "flavor": "`Here, lord, is Herugrim, your ancient blade.` -The Two Towers",
-    "textc": "Attach to a Rohan hero. Restricted.\n Reduce the cost to play Herugrim on Théoden by 1.\nRespone: After attached hero is declared an an attacker, exhaust Herugrim to add attached hero's Willpower to its Attack for this attack.",
+    "textc": "Attach to a Rohan hero. Restricted.\n Reduce the cost to play Herugrim on Th\u00e9oden by 1.\nRespone: After attached hero is declared an an attacker, exhaust Herugrim to add attached hero's Willpower to its Attack for this attack.",
     "name_norm": "Herugrim",
-    "octgn": "9fce5e18-37dc-45c2-8398-df8b5018cb54"
+    "octgn": "9fce5e18-37dc-45c2-8398-df8b5018cb54",
+    "categories": ""
   },
   {
     "name": "Entmoot",
@@ -10408,7 +10666,8 @@
     "flavor": "`...it is a gathering of Ents - which does not often happen nowadays.` -Treebeard, The Two Towers",
     "textc": "Play only if you control at least 1 Ent character.\nAction: Search the top 5 cards of your deck for any number of Ent cards and add them to your hand. Shuffle the other cards back into your deck.",
     "name_norm": "Entmoot",
-    "octgn": "a17465f5-e6f5-4699-b0d7-79355286a065"
+    "octgn": "a17465f5-e6f5-4699-b0d7-79355286a065",
+    "categories": "Card Search"
   },
   {
     "name": "Helm! Helm!",
@@ -10423,10 +10682,11 @@
     "traits": "",
     "keywords": "",
     "text": "Play only after the resolving enemy attacks step is complete.\nCombat Action: Exhaust and discard a Rohan ally you control to choose and discard a non-unique enemy engaged with you.",
-    "flavor": "`Helm is arisen and comes back to war. Helm for Théoden King!` -Riders of Rohan, The Two Towers",
+    "flavor": "`Helm is arisen and comes back to war. Helm for Th\u00e9oden King!` -Riders of Rohan, The Two Towers",
     "textc": "Play only after the resolving enemy attacks step is complete.\nCombat Action: Exhaust and discard a Rohan ally you control to choose and discard a non-unique enemy engaged with you.",
     "name_norm": "Helm Helm",
-    "octgn": "f63da56c-6598-4e01-b245-a9fe49f2251a"
+    "octgn": "f63da56c-6598-4e01-b245-a9fe49f2251a",
+    "categories": ""
   },
   {
     "name": "The Three Hunters",
@@ -10444,7 +10704,8 @@
     "flavor": "`We will make such a chase as shall be accounted a marvel among the Three Kindreds: Elves, Dwarves, and Men. Forth the Three Hunters!` -Aragorn, The Two Towers",
     "textc": "Play only if you control Fellowship Aragorn.\nQuest Action: Choose 3 heroes committed to the quest. Ready those heroes. Until the end of the round, each of the chosen heroes gets +1 Willpower, +1 Attack, and +1 Defense.",
     "name_norm": "The Three Hunters",
-    "octgn": "4101f975-3317-43f8-ba60-19785e01959c"
+    "octgn": "4101f975-3317-43f8-ba60-19785e01959c",
+    "categories": "Readying, Defense Bonus"
   },
   {
     "name": "Shadowfax",
@@ -10459,10 +10720,11 @@
     "traits": " Mount. Mearas.",
     "keywords": "",
     "text": "Attach to Gandalf.\nGandalf gains Ranged and Sentinel.\nAction: Exhaust Shadowfax to ready Gandalf.",
-    "flavor": "`He is the chief of the Mearas, lords of horses and not even Théoden, King of Rohan, has ever looked on a better.` -Gandalf, The Two Towers",
+    "flavor": "`He is the chief of the Mearas, lords of horses and not even Th\u00e9oden, King of Rohan, has ever looked on a better.` -Gandalf, The Two Towers",
     "textc": "Attach to Gandalf.\nGandalf gains Ranged and Sentinel.\nAction: Exhaust Shadowfax to ready Gandalf.",
     "name_norm": "Shadowfax",
-    "octgn": "9f61eee8-cff2-43ad-8f82-7c4efb5ed9b8"
+    "octgn": "9f61eee8-cff2-43ad-8f82-7c4efb5ed9b8",
+    "categories": ""
   },
   {
     "name": "Frodo Baggins",
@@ -10484,7 +10746,8 @@
     "flavor": "`It's my doom, I think, to go to that Shadow yonder, so that a way will be found.` -The Two Towers",
     "textc": "Action: Spend 1 Fellowship resource and exhaust The One Ring to give Frodo Baggins +2 Willpower and +2 Attack until the end of the round.",
     "name_norm": "Frodo Baggins",
-    "octgn": "fe58a6d3-7028-41c1-ab00-5e33e7d77b5f"
+    "octgn": "fe58a6d3-7028-41c1-ab00-5e33e7d77b5f",
+    "categories": ""
   },
   {
     "name": "Faramir",
@@ -10506,7 +10769,8 @@
     "flavor": "`That will be the Captain: he can master both beasts and men'` -Beregond, The Return of the King",
     "textc": "Ranged.\nResponse: After you engage an enemy, ready an ally you control. (Limit once per phase.)",
     "name_norm": "Faramir",
-    "octgn": "8f937f89-b248-4261-9b00-4e3cd9763299"
+    "octgn": "8f937f89-b248-4261-9b00-4e3cd9763299",
+    "categories": "Readying"
   },
   {
     "name": "Damrod",
@@ -10528,7 +10792,8 @@
     "flavor": "`See! Some of the Southrons have broken from the trap and are flying from the road.` -The Two Towers",
     "textc": "Reduce the cost of the first Trap card you play each round by 1 (to a minimum of 0).\nResponse: After a Trap card you control is attached to an enemy, draw 1 card.",
     "name_norm": "Damrod",
-    "octgn": "3f482b9c-aa18-415e-ab9b-58f9c3b328a1"
+    "octgn": "3f482b9c-aa18-415e-ab9b-58f9c3b328a1",
+    "categories": "Card Draw"
   },
   {
     "name": "Anborn",
@@ -10550,7 +10815,8 @@
     "flavor": "`Now I have him at the arrow-point.` -The Two Towers",
     "textc": "Response: After an enemy is added to the staging area, exhaust Anborn to give that enemy +5 engagement cost until the end of the round. Then, deal 1 damage to that enemy.",
     "name_norm": "Anborn",
-    "octgn": "c8b5dd1c-82bc-4733-be1a-484a6e87c3c0"
+    "octgn": "c8b5dd1c-82bc-4733-be1a-484a6e87c3c0",
+    "categories": "Direct Damage"
   },
   {
     "name": "Mablung",
@@ -10572,7 +10838,8 @@
     "flavor": "`But still we will not sit idle and let Him do all as He would.` -The Two Towers",
     "textc": "Response: After Mablung enters play, choose an enemy to get +5 engagement cost until the end of the round. Then, you may engage that enemy, or return it to the staging area.",
     "name_norm": "Mablung",
-    "octgn": "a870e2b3-4b9d-46ea-bc37-425fd682f114"
+    "octgn": "a870e2b3-4b9d-46ea-bc37-425fd682f114",
+    "categories": "Resource Acceleration"
   },
   {
     "name": "Skinbark",
@@ -10594,7 +10861,8 @@
     "flavor": "`He was wounded by the Orcs, and many of his folk and his tree-herds have been murdered and destroyed.` -Treebeard, The Two Towers",
     "textc": "Cannot have restricted attachments. Enters play exhausted.\nWhile Skinbark is attacking alone against an Orc enemy, that enemy does not count its Defense.",
     "name_norm": "Skinbark",
-    "octgn": "df2b2070-240c-4b38-b4c8-29a0d2c789cf"
+    "octgn": "df2b2070-240c-4b38-b4c8-29a0d2c789cf",
+    "categories": ""
   },
   {
     "name": "Gamling",
@@ -10616,7 +10884,8 @@
     "flavor": "`...we have a thousand fit to fight on foot.` said Gamling, an old man, the leader of those that watched the Dike. -The Two Towers",
     "textc": "Response: After a Rohan ally you control is discarded from play, exhaust Gamling to return that ally to your hand.",
     "name_norm": "Gamling",
-    "octgn": "9e944f47-14b0-4890-98d2-584e0abe0eda"
+    "octgn": "9e944f47-14b0-4890-98d2-584e0abe0eda",
+    "categories": ""
   },
   {
     "name": "Staff of Lebethron",
@@ -10634,7 +10903,8 @@
     "flavor": "`They are made of the fair tree lebethron, beloved of the woodwrights of Gondor...` -Faramir, The Two Towers",
     "textc": "Attach to a Gondor or Hobbit hero. Restricted.\nResponse: After attached hero exhausts to defend an attack from an enemy with engagement cost higher than your threat, exhaust Staff of Lebethron to discard a shadow card from that enemy.",
     "name_norm": "Staff of Lebethron",
-    "octgn": "c86cc6c9-8c50-4069-aa85-4d1cc11f796d"
+    "octgn": "c86cc6c9-8c50-4069-aa85-4d1cc11f796d",
+    "categories": "Shadow Control"
   },
   {
     "name": "Ambush",
@@ -10652,7 +10922,8 @@
     "flavor": "`But we have a new errand on this journey: we come to ambush the Men of Harad.` -Mablung, The Two Towers",
     "textc": "Play Ambush into the staging area unattached. If unattached, attach Ambush to the next eligible enemy that enters the staging area.\nCombat Action: The engaged player discards Ambush to declare an attack against the attached enemy.",
     "name_norm": "Ambush",
-    "octgn": "bb89cc13-3049-4001-bd85-916438c6d629"
+    "octgn": "bb89cc13-3049-4001-bd85-916438c6d629",
+    "categories": ""
   },
   {
     "name": "Snowmane",
@@ -10666,11 +10937,12 @@
     "unique": true,
     "traits": " Mount.",
     "keywords": "Restricted.",
-    "text": "Attach to a Rohan hero.\nIf attached hero is Théoden, Snowmane loses the Restricted keyword.\nResponse: After attached hero quests successfully, ready attached hero.",
+    "text": "Attach to a Rohan hero.\nIf attached hero is Th\u00e9oden, Snowmane loses the Restricted keyword.\nResponse: After attached hero quests successfully, ready attached hero.",
     "flavor": "Suddenly the king cried to Snowmane and the horse sprang away. -The Return of the King",
-    "textc": "Attach to a Rohan hero. Restricted.\nIf attached hero is Théoden, Snowmane loses the Restricted keyword.\nResponse: After attached hero quests successfully, ready attached hero.",
+    "textc": "Attach to a Rohan hero. Restricted.\nIf attached hero is Th\u00e9oden, Snowmane loses the Restricted keyword.\nResponse: After attached hero quests successfully, ready attached hero.",
     "name_norm": "Snowmane",
-    "octgn": "b89d39c4-1017-4707-95c3-d60f352d4e95"
+    "octgn": "b89d39c4-1017-4707-95c3-d60f352d4e95",
+    "categories": "Readying"
   },
   {
     "name": "Taste it Again!",
@@ -10688,7 +10960,8 @@
     "flavor": "`We're going on; but we'll settle with you first. Come on, and taste it again! -Sam Gamgee, The Two Towers`",
     "textc": "Response: After a hero you control defends an attack made by an enemy with engagement cost higher than your threat, ready that hero. Until the end of the phase, that hero gets +2 Attack while attacking that enemy.",
     "name_norm": "Taste it Again",
-    "octgn": "1ddaf688-b39b-4d15-8058-1e2957e021ca"
+    "octgn": "1ddaf688-b39b-4d15-8058-1e2957e021ca",
+    "categories": "Readying"
   },
   {
     "name": "In the Shadows",
@@ -10706,7 +10979,8 @@
     "flavor": "He could see them stealing up the slowes, singly or in long files, keeping always to the shade of grove or thicket... -The Two Towers",
     "textc": "Lower the cost to play In the Shadows by 1 for each Hobbit or Ranger hero you control.\nCombat Action: Each enemy engaged with you with an engagement cost higher than your threat gets -1 Attack and -1 Defense until the end of the phase.",
     "name_norm": "In the Shadows",
-    "octgn": "f9351811-479d-4bad-a6b3-ac745739b63f"
+    "octgn": "f9351811-479d-4bad-a6b3-ac745739b63f",
+    "categories": ""
   },
   {
     "name": "Speak Your Promise!",
@@ -10724,15 +10998,7 @@
     "flavor": "For a moment it appeared to Sam that his master had grown and Gollum had shrunk... -The Two Towers",
     "textc": "Action: Ready the Ring-bearer to choose an enemy engaged with you. If the Ring-bearer's Willpower is greater than that enemy's Threat, lower that enemy's Attack and Defense by the difference until the end of the phase.",
     "name_norm": "Speak Your Promise",
-    "octgn": "e2daba5a-f5ac-4fcb-a508-45b3b3cae5a9"
+    "octgn": "e2daba5a-f5ac-4fcb-a508-45b3b3cae5a9",
+    "categories": ""
   }
-
-
-
-
-
-
-
-
-
 ]

--- a/categories.html
+++ b/categories.html
@@ -9,10 +9,13 @@
   <option value="Direct Damage">Direct Damage</option>
   <option value="Healing">Healing</option>
   <option value="Hit Point Bonus">Hit Point Bonus</option>
+  <option value="Location Control">Location Control</option>
   <option value="Readying">Readying</option>
   <option value="Resource Acceleration">Resource Acceleration</option>
   <option value="Resource Smoothing">Resource Smoothing</option>
   <option value="Secrecy">Secrecy</option>
   <option value="Shadow Control">Shadow Control</option>
+  <option value="Staging Area Attack">Staging Area Attack</option>
   <option value="Threat Control">Threat Control</option>
+  <option value="Willpower Bonus">Willpower Bonus</option>
 </select>

--- a/categories.html
+++ b/categories.html
@@ -1,0 +1,18 @@
+<select ng-model="cards.filtersettings.search.categories" class="form-control form-control-sm" id="categoryfilter">
+  <option value="">All Categories</option>
+  <option value="Attack Bonus">Attack Bonus</option>
+  <option value="Card Draw">Card Draw</option>
+  <option value="Card Search">Card Search</option>
+  <option value="Combat Control">Combat Control</option>
+  <option value="Condition Control">Condition Control</option>
+  <option value="Defense Bonus">Defense Bonus</option>
+  <option value="Direct Damage">Direct Damage</option>
+  <option value="Healing">Healing</option>
+  <option value="Hit Point Bonus">Hit Point Bonus</option>
+  <option value="Readying">Readying</option>
+  <option value="Resource Acceleration">Resource Acceleration</option>
+  <option value="Resource Smoothing">Resource Smoothing</option>
+  <option value="Secrecy">Secrecy</option>
+  <option value="Shadow Control">Shadow Control</option>
+  <option value="Threat Control">Threat Control</option>
+</select>

--- a/lotrdb.js
+++ b/lotrdb.js
@@ -328,6 +328,7 @@
       filtersettings.search.name_norm="";
       filtersettings.search.traits="";
       filtersettings.search.textc="";
+      filtersettings.search.categories="";
     };
     this.toggleType = function(t,$event){
       if($event.shiftKey){
@@ -366,6 +367,13 @@
     return {
       restrict: 'E',
       templateUrl: 'traitchoice.html'
+    };
+  });
+
+  app.directive('categories', function() {
+    return {
+      restrict: 'E',
+      templateUrl: 'categories.html'
     };
   });
 

--- a/traitchoice.html
+++ b/traitchoice.html
@@ -1,5 +1,5 @@
 <select ng-model="cards.filtersettings.search.traits" class="form-control form-control-sm" id="traitfilter">
-  <option value="">Search by card trait</option>
+  <option value="">All Traits</option>
   <option value="Archer">Archer</option>
   <option value="Armor">Armor</option>
   <option value="Artifact">Artifact</option>


### PR DESCRIPTION
Adds a filter for categories like Card Draw, Attack Bonus etc. to the deck builder.
Using the categories from Beorn's cardsearch.
